### PR TITLE
fix URL for the W3C Icon

### DIFF
--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -68,7 +68,7 @@
         </ul>
       </aside>
       <p>
-        <a href="https://www.w3.org/"><img alt="W3C" height="48" src="./wot-wg-2023-draft_files/w3c_home" width="72"></a>
+        <a href="https://www.w3.org/"><img alt="W3C" height="48" src="https://www.w3.org/Icons/w3c_home" width="72"></a>
       </p>
     </header>
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/pull/7.html" title="Last updated on Feb 2, 2023, 2:05 PM UTC (390ca50)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/7/dd21167...390ca50.html" title="Last updated on Feb 2, 2023, 2:05 PM UTC (390ca50)">Diff</a>