### PR TITLE
Replace "Modbus" in CoAP Protocol Binding section

### DIFF
--- a/wot-wg-2023-details.html
+++ b/wot-wg-2023-details.html
@@ -472,7 +472,7 @@
     </section>
     <section>
       <h2 id="coap-binding-workitem">CoAP Protocol Binding</h2>
-      <p>The WG will work on the current Modbus Protocol Binding in order to publish it as a standalone normative
+      <p>The WG will work on the current CoAP Protocol Binding in order to publish it as a standalone normative
       document. This will include a CoAP ontology, introduce default values and describe the terms associated with the
       behavior of Things regarding the usage of the CoAP.</p>
     </section>


### PR DESCRIPTION
Reading through the document, I noticed a small typo that is fixed by this PR.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/JKRhb/wot-charter-drafts/pull/18.html" title="Last updated on Jun 14, 2023, 9:33 PM UTC (da32d49)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/18/632c430...JKRhb:da32d49.html" title="Last updated on Jun 14, 2023, 9:33 PM UTC (da32d49)">Diff</a>