### PR TITLE
Suppress Charter History

### DIFF
--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -731,6 +731,7 @@ test suite of every feature defined in the specification.</p>
           This charter has been created according to <a href="https://www.w3.org/Consortium/Process/#GAGeneral">section 3.4</a> of the <a href="https://www.w3.org/Consortium/Process/">Process Document</a>. In the event of a conflict between this document or the provisions of any charter and the W3C Process, the W3C Process shall take precedence.
         </p>
 
+	      <!-- Not needed for "new" charter 
         <section id="history">
           <h3>
             Charter History
@@ -800,6 +801,7 @@ test suite of every feature defined in the specification.</p>
             </tbody>
           </table>
         </section>
+-->
 
         <section id="changelog">
           <h3>Change log</h3>


### PR DESCRIPTION
Resolves #29 

Comment out charter history section.  Not needed for "new" charter.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/pull/30.html" title="Last updated on Feb 14, 2023, 4:12 PM UTC (ae05ebf)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/30/177b9e2...ae05ebf.html" title="Last updated on Feb 14, 2023, 4:12 PM UTC (ae05ebf)">Diff</a>