### PR TITLE
Clean up and consolidate work items

### DIFF
--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -192,56 +192,44 @@
           <p style="text-align:left;font-style:italic">Scope Summary</p>
           After each work item, in parenthesis, we identify the deliverables it may be included in.
           <dl>
-	        <dt><a href="#discovery-updates-workitem"><strong>Discovery Updates</strong></a> 
+	    <dt><strong>Discovery Updates</strong>
             (<a href="#discovery-deliverable">Discovery</a>):</dt>
-            <dd>Backward-compatible updates to the Discovery specification to support
-                additional introduction mechanisms, align with scripting APIs, 
-		            support all Thing Description versions (1.0, 1.1, and 2.0),
-                and improve security and validation.</dd>
-	        <dt><a href="#discovery-thing-models-workitem"><strong>Discovery of Thing Models</strong></a>
-            (<a href="#discovery-deliverable">Discovery</a>):</dt>
-            <dd>Extend discovery support to include storing and returning Thing Models from
-                exploration mechanisms.</dd>
-	        <dt><a href="#discovery-coap-dir-workitem"><strong>Discovery CoAP Directory</strong></a>
-            (<a href="#discovery-deliverable">Discovery</a>):</dt>
-            <dd>Add support for a CoAP API to TD Directory services supporting discovery.</dd>
-	        <dt><a href="#discovery-jsonpath-query-language-workitem"><strong>Discovery JSON Path Query Language</strong></a>
-            (<a href="#discovery-deliverable">Discovery</a>):</dt>
-            <dd>Add support for JSONPath queries to TD Directory services.</dd>
-	        <dt><a href="#discovery-query-filters-workitem"><strong>Discovery Query Filters</strong></a>
-            (<a href="#discovery-deliverable">Discovery</a>):</dt>
-            <dd>Add support for query filters for common use cases to TD Directory services.</dd>
-          </dd>
-	        <dt><a href="#geolocation-workitem"><strong>Geolocation</strong></a>
+            <dd>Updates to the Discovery specification to support
+                additional introduction mechanisms, 
+		improve query mechanisms in directories,
+		align with scripting APIs, 
+		support all Thing Description versions (1.0, 1.1, and 2.0) and Thing Models,
+                better support CoAP,
+		and improve security and validation.
+            </dd>
+	    <dt><strong>Geolocation</strong>
             (<a href="#discovery-deliverable">Discovery</a>,
              <a href="#thing-description-deliverable">Thing Description</a>,
              <a href="#profiles-deliverable">Profiles</a>):</dt>
             <dd>Define mechanisms for embedding of static geolocation information in TDs, 
                 annotation of data models for dynamic geolocation, and spatial filters in
                 TD Directory queries for geospatially-limited discovery.</dd>
-	        <dt><a href="#onboarding-workitem"><strong>Onboarding</strong></a> 
+	   <dt><strong>Onboarding</strong>
            (<a href="#architecture-deliverable">Architecture</a>,
             <a href="#discovery-deliverable">Discovery</a>):</dt>
            <dd>Define lifecycle process to establish mutual trust and identification.</dd>
-	        <dt><a href="#sec-ontology-workitem"><strong>Security Scheme Ontology</strong></a>
+	   <dt><strong>Security Scheme Ontology</strong>
            (<a href="#thing-description-deliverable">Thing Description</a>,
             <a href="#binding-deliverable">Binding Templates</a>):</dt>
            <dd>Refactor security schemes to use Protocol Binding ontologies for protocol-specific security schemes.</dd>
-          <dt><a href="#signing-workitem"><strong>Signing</strong></a> 
+           <dt><strong>Signing</strong> 
            (<a href="#discovery-deliverable">Discovery</a>,
             <a href="#thing-description-deliverable">Thing Description</a>):</dt>
            <dd>Add support for Thing Description signing and support signed Thing Descriptions in the Discovery process.
             Requires definition of Thing Description canonicalization.</dd>
-          <dt>
-            <a href="#timeseries-workitem"><strong>Timeseries</strong></a> 
+          <dt><strong>Timeseries</strong> 
             (<a href="#thing-description-deliverable">Thing Description</a>,
-            <a href="#binding-deliverable">Binding Templates</a>):
-          </dt>
+            <a href="#binding-deliverable">Binding Templates</a>):</dt>
           <dd>
             Add support for describing historical values or value changes of affordances to the TD specification in an interoperable way with existing solutions.
           </dd>
           <dt>
-            <a href="#payload-protocols-workitem"><strong>Payload Driven Protocols</strong></a> 
+            <strong>Payload Driven Protocols</strong>
             (<a href="#thing-description-deliverable">Thing Description</a>,
             <a href="#binding-deliverable">Binding Templates</a>,
             <a href="#profiles-deliverable">Profiles</a>):
@@ -250,7 +238,7 @@
             Add support for describing protocols that depend on specific payload structures on top of the protocol bindings.
           </dd>
           <dt>
-            <a href="#manageable-actions-workitem"><strong>Manageable Actions</strong></a> 
+            <strong>Manageable Actions</strong>
             (<a href="#thing-description-deliverable">Thing Description</a>,
             <a href="#profiles-deliverable">Profiles</a>):
           </dt>
@@ -258,7 +246,7 @@
             Add support for describing actions that can be managed after their invocation.
           </dd>
           <dt>
-            <a href="#init-connection-workitem"><strong>Initial / Common Connection Description</strong></a> 
+            <strong>Initial / Common Connection Description</strong> 
             (<a href="#thing-description-deliverable">Thing Description</a>,
             <a href="#binding-deliverable">Binding Templates</a>):
           </dt>
@@ -266,7 +254,7 @@
             Add support for a connection description to be shared among affordance operations
           </dd>
           <dt>
-            <a href="#canon-workitem"><strong>Canonicalization</strong></a> 
+            <strong>Canonicalization</strong>
             (<a href="#thing-description-deliverable">Thing Description</a>,
             <a href="#discovery-deliverable">Discovery</a>):
           </dt>
@@ -274,14 +262,14 @@
             Add a canonicalization algorithm.
           </dd>
           <dt>
-            <a href="#inline-sec-workitem"><strong>Inline Security</strong></a>
+            <strong>Inline Security</strong>
             (<a href="#thing-description-deliverable">Thing Description</a>):
           </dt>
           <dd>
             Add a way to describe security definitions in a simplified fashion for simple cases.
           </dd>
           <dt>
-            <a href="#td-versioning-workitem"><strong>TD Versioning</strong></a>
+            <strong>TD Versioning</strong>
             (<a href="#thing-description-deliverable">Thing Description</a>,
             <a href="#discovery-deliverable">Discovery</a>):
           </dt>
@@ -289,7 +277,7 @@
             Explain the semantics on how to version Thing Descriptions.
           </dd>
           <dt>
-            <a href="#td-consumption-workitem"><strong>Normative TD Parsing, Consuming and Validation</strong></a>
+            <strong>Normative TD Parsing, Consuming and Validation</strong>
             (<a href="#thing-description-deliverable">Thing Description</a>,
             <a href="#scripting-deliverable">Scripting API</a>,
             <a href="#profiles-deliverable">Profiles</a>):
@@ -298,59 +286,29 @@
             Define normative algorithms for parsing, consuming and validating Thing Descriptions.
           </dd>
           <dt>
-            <a href="#td-linting-workitem"><strong>Linting mechanism for TDs</strong></a>
+            <strong>Linting mechanism for TDs</strong>
             (<a href="#thing-description-deliverable">Thing Description</a>,
             <a href="#profiles-deliverable">Profiles</a>):
           </dt>
           <dd>
             Define a linting mechanism for Thing Descriptions that allows adding additional rules.
           </dd>
-          <dt><a href="#binding-mechanism-workitem"><strong>Binding Mechanism</strong></a> 
+          <dt><strong>Binding Mechanism</strong>
             (<a href="#binding:-deliverable">Binding Templates</a>,
               <a href="#thing-description-deliverable">Thing Description</a>,
               <a href="#security-deliverable">Security</a>,
               <a href="#profiles-deliverable">Profiles</a>):</dt>
             <dd>Add normative binding mechanism</dd>
-          <dt><a href="#http-binding-workitem"><strong>HTTP Protocol Binding</strong></a> 
+          <dt><strong>Protocol Bindings</strong>
             (<a href="#binding:-deliverable">Binding Templates</a>):</dt>
-            <dd>Add normative HTTP binding</dd>
-          <dt><a href="#coap-binding-workitem"><strong>CoAP Protocol Binding</strong></a> 
-              (<a href="#binding:-deliverable">Binding Templates</a>):</dt>
-              <dd>Add normative CoAP binding</dd>
-          <dt><a href="#mqtt-binding-workitem"><strong>MQTT Protocol Binding</strong></a> 
+          <dd>Define bindings for specific protocols of interest.</dd>
+          <dt><strong>Payload Bindings</strong>
             (<a href="#binding:-deliverable">Binding Templates</a>):</dt>
-            <dd>Add normative MQTT binding</dd>
-          <dt><a href="#modbus-binding-workitem"><strong>Modbus Protocol Binding</strong></a> 
-            (<a href="#binding:-deliverable">Binding Templates</a>):</dt>
-            <dd>Add normative Modbus binding</dd>
-          <dt><a href="#bacnet-binding-workitem"><strong>BACnet Protocol Binding</strong></a> 
-            (<a href="#binding:-deliverable">Binding Templates</a>):</dt>
-            <dd>Add normative BACnet binding</dd>
-          <dt><a href="#opcua-binding-workitem"><strong>OPC UA Protocol Binding</strong></a> 
-            (<a href="#binding:-deliverable">Binding Templates</a>):</dt>
-            <dd>Add normative OPC UA binding</dd>
-          <dt><a href="#grpc-binding-workitem"><strong>gRPC Protocol Binding</strong></a> 
-            (<a href="#binding:-deliverable">Binding Templates</a>):</dt>
-            <dd>Add normative gRPC binding</dd>
-          <dt><a href="#json-binding-workitem"><strong>JSON Payload Binding</strong></a> 
-            (<a href="#binding:-deliverable">Binding Templates</a>):</dt>
-            <dd>Add normative JSON binding</dd>
-          <dt><a href="#cbor-binding-workitem"><strong>CBOR Payload Binding</strong></a> 
-            (<a href="#binding:-deliverable">Binding Templates</a>):</dt>
-            <dd>Add normative CBOR binding</dd>
-          <dt><a href="#xml-binding-workitem"><strong>XML Payload Binding</strong></a> 
-            (<a href="#binding:-deliverable">Binding Templates</a>):</dt>
-            <dd>Add normative XML binding</dd>
-          <dt><a href="#cloudevents-binding-workitem"><strong>CloudEvents Payload Binding</strong></a> 
-            (<a href="#binding:-deliverable">Binding Templates</a>):</dt>
-            <dd>Add normative CloudEvents binding</dd>
-          <dt><a href="#echonet-binding-workitem"><strong>ECHONET Lite Web API Combination Binding</strong></a> 
-            (<a href="#binding:-deliverable">Binding Templates</a>):</dt>
-            <dd>Add normative ECHONET Lite Web API binding</dd>
-	        <dt><a href="#wotcg-coordination"><strong>WoT CG Coordination</strong></a>:</dt>
+            <dd>Define bindings for payload formats of interest.</dd>
+	  <dt><strong>WoT CG Coordination</strong>:</dt>
              <dd>Collaborate on community outreach of the WG reports to increase adoption and implementation,
              as well as collect feedback from the wider community.</dd>
-          <dt><a href="#profiles-workitem"><strong>Interoperability Profiles</strong></a>
+          <dt><strong>Interoperability Profiles</strong>
             (<a href="#profiles-deliverable">Profiles</a>):</dt>
             <dd>Support out-of-the-box interoperabilty via a profiling mechanism.</dd>
         </dl>


### PR DESCRIPTION
Resolves #22 
Partially addresses #24 

- Remove hyperlinks to deleted "details" sections
- Consolidate Discovery items into one "Discovery updates" item
- Consolidate Protocol Bindings into one work item
- Consolidate Payload Bindings into one work item


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/pull/31.html" title="Last updated on Feb 15, 2023, 1:37 PM UTC (dfa3de3)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/31/44bda2a...dfa3de3.html" title="Last updated on Feb 15, 2023, 1:37 PM UTC (dfa3de3)">Diff</a>