### PR TITLE
Add W3C group coordination list

### DIFF
--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -501,15 +501,53 @@ test suite of every feature defined in the specification.</p>
         <section>
           <h3 id="w3c-coordination">W3C Groups</h3>
           <dl>
+<!--
             <dt><a href="https://w3c.github.io/charter-drafts/charter-template.html"><i class="todo">[other name]</i> Working Group</a></dt>
-            <dd><i class="todo">[specific nature of liaison]</i></dd>
+              <dd><i class="todo">[specific nature of liaison]</i></dd>
+-->
             <dt><a href="https://www.w3.org/community/wot/">Web of Things Community Group</a></dt>
-            <dd>For collaboration on community outreach of the WG reports to increase adoption and implementation, as well as collecting feedback from the wider community. Also see <a href="#wotcg-coordination">WoT CG Coordination.</a></dd>
+              <dd>For collaboration on community outreach of the WG reports to increase adoption and implementation, 
+		  as well as collecting feedback from the wider community. 
+		  Meetings held in English.
+		  Also see <a href="#wotcg-coordination">WoT CG Coordination.</a></dd>	
+            <dt><a href="https://www.w3.org/community/wot/">Web of Things Japanese Community Group</a></dt>
+              <dd>For collaboration on community outreach of the WG reports to increase adoption and implementation, 
+		  as well as collecting feedback from the wider community. 
+		  Meetings held in Japanese.
+		  Also see <a href="#wotcg-coordination">WoT CG Coordination.</a></dd>	
+            <dt><a href="https://www.w3.org/groups/ig/wot">Web of Things Interest Group</a></dt>
+	      <dd>For collaboration as outlined in <a href="#scope">Scope</a>.</dd>
+	    <dt><a href="https://www.w3.org/2018/json-ld-wg/">JSON-LD Working Group</a></dt>
+	      <dd>For collaboration on JSON-LD features and WoT use cases.</dd>
+	    <dt><a href="https://www.w3.org/community/exi-next/">Efficient Extensible Interchange Community Group</a></dt>
+	      <dd>In relation to efficient interchange for Thing Descriptions.</dd>
+	    <dt><a href="https://www.w3.org/auto/">Web and Automotive Business &amp; Working Groups</a></dt>
+	      <dd>For collaboration on technologies and requirements relating to connected cars and the Web of Things.</dd>
+	    <dt><a href="https://www.w3.org/2009/dap/">Device and Sensors Working Group</a></dt>
+	      <dd>For coordination on APIs for sensors and actuators.</dd>
+	    <dt><a href="">Decentralized Identifier Working Group</a></dt>
+	      <dd>For coordination on identity management and information lifecycle.</dd>
+	    <dt><a href="https://www.w3.org/web-networks/">Web &amp; Networks Interest Group</a></dt>
+	      <dd>For collaboration on networking and computing technologies on the edge and in the 
+		  cloud when exposing interactions between Things.</dd>
+	    <dt><a href="https://www.w3.org/WAI/APA/">Accessible Platform Architectures Working Group</a></dt>
+	      <dd>For coordination on impact of WoT technologies on accessibility for users with disabilities,
+		  and to support new capabilities that help leverage WoT connectivity and sensor networks
+		  for disability support in public and private spaces.</dd>
+	    <dt><a href="https://www.w3.org/Privacy/">Privacy Interest Group</a></dt>
+	      <dd>In addition to horizontal review, during development of deliverables such
+                  as discovery and information lifecycle that
+                  require the development of a privacy-preserving architecture,
+                  close technical collaboration with the Privacy Interest Group will be needed.</dd>
+	    <dt><a href="https://www.w3.org/community/iotschema/">Schema Extensions for IoT Community Group</a></dt>
+	       <dd>For collaboration on extensions to Schema.org for IoT use cases.</dd>
           </dl>
 
+<!--
           <p class="issue"><b>Note:</b> Do not list horizontal groups here, only specific WGs relevant to your work.</p>
           <p class="issue"><b>Note:</b> Do not bury normative text inside the liaison section.
             Instead, put it in the scope section.</p>
+-->
         </section>
 
         <section>

--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -347,9 +347,6 @@
           <dt><a href="#echonet-binding-workitem"><strong>ECHONET Lite Web API Combination Binding</strong></a> 
             (<a href="#binding:-deliverable">Binding Templates</a>):</dt>
             <dd>Add normative ECHONET Lite Web API binding</dd>
-	        <dt><a href="#wotcg-coordination"><strong>WoT CG Coordination</strong></a>:</dt>
-             <dd>Collaborate on community outreach of the WG reports to increase adoption and implementation,
-             as well as collect feedback from the wider community.</dd>
           <dt><a href="#profiles-workitem"><strong>Interoperability Profiles</strong></a>
             (<a href="#profiles-deliverable">Profiles</a>):</dt>
             <dd>Support out-of-the-box interoperabilty via a profiling mechanism.</dd>
@@ -509,12 +506,12 @@ test suite of every feature defined in the specification.</p>
               <dd>For collaboration on community outreach of the WG reports to increase adoption and implementation, 
 		  as well as collecting feedback from the wider community. 
 		  Meetings held in English.
-		  Also see <a href="#wotcg-coordination">WoT CG Coordination.</a></dd>	
+		  </dd>	
             <dt><a href="https://www.w3.org/community/wot/">Web of Things Japanese Community Group</a></dt>
               <dd>For collaboration on community outreach of the WG reports to increase adoption and implementation, 
 		  as well as collecting feedback from the wider community. 
 		  Meetings held in Japanese.
-		  Also see <a href="#wotcg-coordination">WoT CG Coordination.</a></dd>	
+		  </dd>	
             <dt><a href="https://www.w3.org/groups/ig/wot">Web of Things Interest Group</a></dt>
 	      <dd>For collaboration as outlined in <a href="#scope">Scope</a>.</dd>
 	    <dt><a href="https://www.w3.org/2018/json-ld-wg/">JSON-LD Working Group</a></dt>

--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -507,7 +507,7 @@ test suite of every feature defined in the specification.</p>
 		  as well as collecting feedback from the global community. 
 		  Meetings held in English.
 		  </dd>	
-            <dt><a href="https://www.w3.org/community/wot/">Web of Things Japanese Community Group</a></dt>
+            <dt><a href="https://www.w3.org/community/wot-jp/">Web of Things Japanese Community Group</a></dt>
               <dd>For collaboration on community outreach of the WG reports to increase adoption and implementation, 
 		  as well as collecting feedback from the Japanese community. 
 		  Meetings held in Japanese.

--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -504,12 +504,12 @@ test suite of every feature defined in the specification.</p>
 -->
             <dt><a href="https://www.w3.org/community/wot/">Web of Things Community Group</a></dt>
               <dd>For collaboration on community outreach of the WG reports to increase adoption and implementation, 
-		  as well as collecting feedback from the wider community. 
+		  as well as collecting feedback from the global community. 
 		  Meetings held in English.
 		  </dd>	
             <dt><a href="https://www.w3.org/community/wot/">Web of Things Japanese Community Group</a></dt>
               <dd>For collaboration on community outreach of the WG reports to increase adoption and implementation, 
-		  as well as collecting feedback from the wider community. 
+		  as well as collecting feedback from the Japanese community. 
 		  Meetings held in Japanese.
 		  </dd>	
             <dt><a href="https://www.w3.org/groups/ig/wot">Web of Things Interest Group</a></dt>


### PR DESCRIPTION
Resolves #27 

- Copy of list from previous charter
- Add WoT JP CG, paralleling WoT CG structure (both link back to the same work item; I would edit that too but don't want to cause a conflict with other PRs)
- comment out boilerplate and todos


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/pull/32.html" title="Last updated on Feb 15, 2023, 1:25 PM UTC (1a84494)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/32/177b9e2...1a84494.html" title="Last updated on Feb 15, 2023, 1:25 PM UTC (1a84494)">Diff</a>