### PR TITLE
update external orga list

### DIFF
--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -1,122 +1,130 @@
 <!DOCTYPE html>
 <!-- saved from url=(0058)https://w3c.github.io/charter-drafts/charter-template.html -->
-<html lang="en-US"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    
+<html lang="en-US">
 
-    <title>[DRAFT] Web of Things Working Group Charter</title>
-
-    <link rel="stylesheet" href="https://www.w3.org/2005/10/w3cdoc.css" type="text/css" media="screen">
-    <link rel="stylesheet" type="text/css" href="https://www.w3.org/OldGuide/pubrules-style.css">
-    <link rel="stylesheet" type="text/css" href="https://www.w3.org/2006/02/charter-style.css">
-    <style>
-      main {
-        max-width: 60em;
-        margin: 0 auto;
-      }
-
-      ul#navbar {
-        font-size: small;
-      }
-
-      dt.spec {
-        font-weight: bold;
-      }
-
-      dt.spec new {
-        background: yellow;
-      }
-
-      ul.out-of-scope > li {
-        font-weight: bold;
-      }
-
-      ul.out-of-scope > li > ul > li{
-        font-weight: normal;
-      }
-
-      .issue {
-        background: cornsilk;
-        font-style: italic;
-      }
-
-      .todo {
-        color: #900;
-      }
-
-      footer {
-        font-size: small;
-      }
-    </style>
-  </head>
-  <body>
-    <header id="header">
-      <aside>
-        <ul id="navbar">
-          <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#background">Background</a></li>
-          <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#scope">Scope</a></li>
-          <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#deliverables">Deliverables</a></li>
-		  <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#success-criteria">Success Criteria</a></li>
-          <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#coordination">Coordination</a></li>
-          <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#participation">Participation</a></li>
-          <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#communication">Communication</a></li>
-          <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#decisions">Decision Policy</a></li>
-          <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#patentpolicy">Patent Policy</a></li>
-          <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#licensing">Licensing</a></li>
-          <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#about">About this Charter</a></li>
-        </ul>
-      </aside>
-      <p>
-        <a href="https://www.w3.org/"><img alt="W3C" height="48" src="https://www.w3.org/Icons/w3c_home" width="72"></a>
-      </p>
-    </header>
+<head>
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
 
 
-    <main>
-      <h1 id="title">PROPOSED Web of Things Working Group Charter</h1>
-      <!-- delete PROPOSED after AC review completed -->
+  <title>[DRAFT] Web of Things Working Group Charter</title>
 
-      <p class="mission">
-	The <strong>mission</strong> of the
-        <a href="https://www.w3.org/groups/wg/wot">Web of Things Working Group</a>
-        is to counter the fragmentation of the IoT through
-        the specification of building blocks
-        that enable easy integration of IoT devices and services
-        across IoT platforms and application domains.
-        These building blocks should complement and enhance existing standards.
-        This
-        Working Group Charter
-        covers those aspects that the
-        <a href="http://www.w3.org/groups/ig/wot">Web of Things Interest Group</a>
-        <a href="https://www.w3.org/2021/12/wot-ig-2021.html">(charter here)</a>
-        believes are mature enough to progress to W3C Recommendations.
+  <link rel="stylesheet" href="https://www.w3.org/2005/10/w3cdoc.css" type="text/css" media="screen">
+  <link rel="stylesheet" type="text/css" href="https://www.w3.org/OldGuide/pubrules-style.css">
+  <link rel="stylesheet" type="text/css" href="https://www.w3.org/2006/02/charter-style.css">
+  <style>
+    main {
+      max-width: 60em;
+      margin: 0 auto;
+    }
+
+    ul#navbar {
+      font-size: small;
+    }
+
+    dt.spec {
+      font-weight: bold;
+    }
+
+    dt.spec new {
+      background: yellow;
+    }
+
+    ul.out-of-scope>li {
+      font-weight: bold;
+    }
+
+    ul.out-of-scope>li>ul>li {
+      font-weight: normal;
+    }
+
+    .issue {
+      background: cornsilk;
+      font-style: italic;
+    }
+
+    .todo {
+      color: #900;
+    }
+
+    footer {
+      font-size: small;
+    }
+  </style>
+</head>
+
+<body>
+  <header id="header">
+    <aside>
+      <ul id="navbar">
+        <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#background">Background</a></li>
+        <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#scope">Scope</a></li>
+        <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#deliverables">Deliverables</a></li>
+        <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#success-criteria">Success Criteria</a>
+        </li>
+        <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#coordination">Coordination</a></li>
+        <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#participation">Participation</a></li>
+        <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#communication">Communication</a></li>
+        <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#decisions">Decision Policy</a></li>
+        <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#patentpolicy">Patent Policy</a></li>
+        <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#licensing">Licensing</a></li>
+        <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#about">About this Charter</a></li>
+      </ul>
+    </aside>
+    <p>
+      <a href="https://www.w3.org/"><img alt="W3C" height="48" src="https://www.w3.org/Icons/w3c_home" width="72"></a>
+    </p>
+  </header>
+
+
+  <main>
+    <h1 id="title">PROPOSED Web of Things Working Group Charter</h1>
+    <!-- delete PROPOSED after AC review completed -->
+
+    <p class="mission">
+      The <strong>mission</strong> of the
+      <a href="https://www.w3.org/groups/wg/wot">Web of Things Working Group</a>
+      is to counter the fragmentation of the IoT through
+      the specification of building blocks
+      that enable easy integration of IoT devices and services
+      across IoT platforms and application domains.
+      These building blocks should complement and enhance existing standards.
+      This
+      Working Group Charter
+      covers those aspects that the
+      <a href="http://www.w3.org/groups/ig/wot">Web of Things Interest Group</a>
+      <a href="https://www.w3.org/2021/12/wot-ig-2021.html">(charter here)</a>
+      believes are mature enough to progress to W3C Recommendations.
       <!-- the link to the group is ALWAYS that available from https://www.w3.org/groups/wg or https://www.w3.org/groups/ig because each group page can then point to a different homepage, but not the other way around. -->
 
-      <div class="noprint">
-        <p class="join"><a href="https://www.w3.org/groups/wg/wot/join">Join the Web of Things Working Group.</a></p>
-      </div>
+    <div class="noprint">
+      <p class="join"><a href="https://www.w3.org/groups/wg/wot/join">Join the Web of Things Working Group.</a></p>
+    </div>
 
-      <p style="padding: 0.5ex; border: 1px solid green"> This proposed charter is available
-        on <a href="https://github.com/w3c/wot">GitHub</a>.
-        Feel free to raise <a href="https://github.com/w3c/wot/issues">issues</a>.
-      </p>
+    <p style="padding: 0.5ex; border: 1px solid green"> This proposed charter is available
+      on <a href="https://github.com/w3c/wot">GitHub</a>.
+      Feel free to raise <a href="https://github.com/w3c/wot/issues">issues</a>.
+    </p>
 
-      <div id="details">
-        <table class="summary-table">
-          <tbody><tr id="Status">
+    <div id="details">
+      <table class="summary-table">
+        <tbody>
+          <tr id="Status">
             <th>
               Charter Status
             </th>
             <td>
-              See the <a href="https://www.w3.org/groups/wg/wot/charters">group status page</a> 
-	      and <a href="https://w3c.github.io/charter-drafts/charter-template.html#history">detailed change history</a>.
+              See the <a href="https://www.w3.org/groups/wg/wot/charters">group status page</a>
+              and <a href="https://w3c.github.io/charter-drafts/charter-template.html#history">detailed change
+                history</a>.
             </td>
-          </tr>		
+          </tr>
           <tr id="Duration">
             <th>
               Start date
             </th>
             <td>
-              <i class="todo">1 June 2023 (ESTIMATED) (date of the "Call for Participation", when the charter is approved)</i>
+              <i class="todo">1 June 2023 (ESTIMATED) (date of the "Call for Participation", when the charter is
+                approved)</i>
             </td>
           </tr>
           <tr id="CharterEnd">
@@ -140,7 +148,7 @@
               Team Contacts
             </th>
             <td>
-	      <a href="mailto:ashimura@w3.org">Kazuyuki Ashimura</a> (0.2 <abbr title="Full-Time Equivalent">FTE</abbr>)
+              <a href="mailto:ashimura@w3.org">Kazuyuki Ashimura</a> (0.2 <abbr title="Full-Time Equivalent">FTE</abbr>)
             </td>
           </tr>
           <tr>
@@ -148,85 +156,97 @@
               Meeting Schedule
             </th>
             <td>
-	      <strong>Teleconferences:</strong>
-		    Weekly with additional topic specific calls as appropriate.<br/>
+              <strong>Teleconferences:</strong>
+              Weekly with additional topic specific calls as appropriate.<br />
               <br>
               <strong>Face-to-face:</strong>
-		    We will meet during the W3C's annual Technical Plenary week;
-		    additional face-to-face meetings may be scheduled by consent of the participants,
-		    with no more than four (4) face-to-face meetings in total per year.
+              We will meet during the W3C's annual Technical Plenary week;
+              additional face-to-face meetings may be scheduled by consent of the participants,
+              with no more than four (4) face-to-face meetings in total per year.
             </td>
           </tr>
-        </tbody></table>
+        </tbody>
+      </table>
 
-        <p class="issue"><b>Note:</b> The <a href="https://www.w3.org/Consortium/Process/#WGCharter">W3C Process Document</a> requires “The level of confidentiality of the group's proceedings and deliverables”; however, it does not mandate where this appears. Since all W3C Working Groups should be chartered as public, this notice has been moved from the essentials table to the <a href="https://w3c.github.io/charter-drafts/charter-template.html#public">communication section</a>.</p>
-      </div>
+      <p class="issue"><b>Note:</b> The <a href="https://www.w3.org/Consortium/Process/#WGCharter">W3C Process
+          Document</a> requires “The level of confidentiality of the group's proceedings and deliverables”; however, it
+        does not mandate where this appears. Since all W3C Working Groups should be chartered as public, this notice has
+        been moved from the essentials table to the <a
+          href="https://w3c.github.io/charter-drafts/charter-template.html#public">communication section</a>.</p>
+    </div>
 
-      <div id="background" class="background">
-        <!-- Brief background of landscape, technology, and relationship to the Web, users, developers, implementers, and industry. -->
-	<p>This working group is tasked with the standardization
-           or extension of several technological building blocks
-           identified by the
-           <a href="https://www.w3.org/groups/ig/wot">Web of Things Interest Group</a> (IG)
-           as being important to advancing the Web of Things.
-           The WoT building blocks are intended to complement existing
-           and emerging IoT standards by focusing on enabling cross-platform and cross-domain interoperability.
-           The proposed work items are summarized in the <a href="#scope">Scope</a> section, and
-	   include <span class="todo">(REVISE) interoperability profiles for particular usage contexts;
-           vocabulary support for new protocols, security schemes, and links;
-           standardized discovery mechanisms;
-	   and improvements to Thing Description Templates.</span>
-           These work items will be prototyped and tested by multiple implementors in
-           WoT IG <a href="https://w3c.github.io/wot/current-practices/wot-practices.html#plugfests">PlugFests</a>
-           during development.
-           Open-source implementations will be prioritized.</p>
-      </div>
+    <div id="background" class="background">
+      <!-- Brief background of landscape, technology, and relationship to the Web, users, developers, implementers, and industry. -->
+      <p>This working group is tasked with the standardization
+        or extension of several technological building blocks
+        identified by the
+        <a href="https://www.w3.org/groups/ig/wot">Web of Things Interest Group</a> (IG)
+        as being important to advancing the Web of Things.
+        The WoT building blocks are intended to complement existing
+        and emerging IoT standards by focusing on enabling cross-platform and cross-domain interoperability.
+        The proposed work items are summarized in the <a href="#scope">Scope</a> section, and
+        include <span class="todo">(REVISE) interoperability profiles for particular usage contexts;
+          vocabulary support for new protocols, security schemes, and links;
+          standardized discovery mechanisms;
+          and improvements to Thing Description Templates.</span>
+        These work items will be prototyped and tested by multiple implementors in
+        WoT IG <a href="https://w3c.github.io/wot/current-practices/wot-practices.html#plugfests">PlugFests</a>
+        during development.
+        Open-source implementations will be prioritized.
+      </p>
+    </div>
 
-      <section id="scope" class="scope">
-        <h2>Scope</h2>
-        <!-- What exactly is in scope, and out of scope.
+    <section id="scope" class="scope">
+      <h2>Scope</h2>
+      <!-- What exactly is in scope, and out of scope.
           For legal review. Be brief. -->
-        <p>The Working Group has the following work items in scope:</p>
+      <p>The Working Group has the following work items in scope:</p>
 
-        <div class="summary">
-          <p style="text-align:left;font-style:italic">Scope Summary</p>
-          After each work item, in parenthesis, we identify the deliverables it may be included in.
-          <dl>
-	    <dt><strong>Discovery Updates</strong>
+      <div class="summary">
+        <p style="text-align:left;font-style:italic">Scope Summary</p>
+        After each work item, in parenthesis, we identify the deliverables it may be included in.
+        <dl>
+          <dt><strong>Discovery Updates</strong>
             (<a href="#discovery-deliverable">Discovery</a>):</dt>
-            <dd>Updates to the Discovery specification to support
-                additional introduction mechanisms, 
-		improve query mechanisms in directories,
-		align with scripting APIs, 
-		support all Thing Description versions (1.0, 1.1, and 2.0) and Thing Models,
-                better support CoAP,
-		and improve security and validation.
-            </dd>
-	    <dt><strong>Geolocation</strong>
+          <dd>Updates to the Discovery specification to support
+            additional introduction mechanisms,
+            improve query mechanisms in directories,
+            align with scripting APIs,
+            support all Thing Description versions (1.0, 1.1, and 2.0) and Thing Models,
+            better support CoAP,
+            and improve security and validation.
+          </dd>
+          <dt><strong>Geolocation</strong>
             (<a href="#discovery-deliverable">Discovery</a>,
-             <a href="#thing-description-deliverable">Thing Description</a>,
-             <a href="#profiles-deliverable">Profiles</a>):</dt>
-            <dd>Define mechanisms for embedding of static geolocation information in TDs, 
-                annotation of data models for dynamic geolocation, and spatial filters in
-                TD Directory queries for geospatially-limited discovery.</dd>
-	   <dt><strong>Onboarding</strong>
-           (<a href="#architecture-deliverable">Architecture</a>,
-            <a href="#discovery-deliverable">Discovery</a>):</dt>
-           <dd>Define lifecycle process to establish mutual trust and identification.</dd>
-	   <dt><strong>Security Scheme Ontology</strong>
-           (<a href="#thing-description-deliverable">Thing Description</a>,
-            <a href="#binding-deliverable">Binding Templates</a>):</dt>
-           <dd>Refactor security schemes to use Protocol Binding ontologies for protocol-specific security schemes.</dd>
-           <dt><strong>Signing</strong> 
-           (<a href="#discovery-deliverable">Discovery</a>,
-            <a href="#thing-description-deliverable">Thing Description</a>):</dt>
-           <dd>Add support for Thing Description signing and support signed Thing Descriptions in the Discovery process.
-            Requires definition of Thing Description canonicalization.</dd>
-          <dt><strong>Timeseries</strong> 
+            <a href="#thing-description-deliverable">Thing Description</a>,
+            <a href="#profiles-deliverable">Profiles</a>):
+          </dt>
+          <dd>Define mechanisms for embedding of static geolocation information in TDs,
+            annotation of data models for dynamic geolocation, and spatial filters in
+            TD Directory queries for geospatially-limited discovery.</dd>
+          <dt><strong>Onboarding</strong>
+            (<a href="#architecture-deliverable">Architecture</a>,
+            <a href="#discovery-deliverable">Discovery</a>):
+          </dt>
+          <dd>Define lifecycle process to establish mutual trust and identification.</dd>
+          <dt><strong>Security Scheme Ontology</strong>
             (<a href="#thing-description-deliverable">Thing Description</a>,
-            <a href="#binding-deliverable">Binding Templates</a>):</dt>
+            <a href="#binding-deliverable">Binding Templates</a>):
+          </dt>
+          <dd>Refactor security schemes to use Protocol Binding ontologies for protocol-specific security schemes.</dd>
+          <dt><strong>Signing</strong>
+            (<a href="#discovery-deliverable">Discovery</a>,
+            <a href="#thing-description-deliverable">Thing Description</a>):
+          </dt>
+          <dd>Add support for Thing Description signing and support signed Thing Descriptions in the Discovery process.
+            Requires definition of Thing Description canonicalization.</dd>
+          <dt><strong>Timeseries</strong>
+            (<a href="#thing-description-deliverable">Thing Description</a>,
+            <a href="#binding-deliverable">Binding Templates</a>):
+          </dt>
           <dd>
-            Add support for describing historical values or value changes of affordances to the TD specification in an interoperable way with existing solutions.
+            Add support for describing historical values or value changes of affordances to the TD specification in an
+            interoperable way with existing solutions.
           </dd>
           <dt>
             <strong>Payload Driven Protocols</strong>
@@ -235,7 +255,8 @@
             <a href="#profiles-deliverable">Profiles</a>):
           </dt>
           <dd>
-            Add support for describing protocols that depend on specific payload structures on top of the protocol bindings.
+            Add support for describing protocols that depend on specific payload structures on top of the protocol
+            bindings.
           </dd>
           <dt>
             <strong>Manageable Actions</strong>
@@ -246,7 +267,7 @@
             Add support for describing actions that can be managed after their invocation.
           </dd>
           <dt>
-            <strong>Initial / Common Connection Description</strong> 
+            <strong>Initial / Common Connection Description</strong>
             (<a href="#thing-description-deliverable">Thing Description</a>,
             <a href="#binding-deliverable">Binding Templates</a>):
           </dt>
@@ -295,436 +316,465 @@
           </dd>
           <dt><strong>Binding Mechanism</strong>
             (<a href="#binding:-deliverable">Binding Templates</a>,
-              <a href="#thing-description-deliverable">Thing Description</a>,
-              <a href="#security-deliverable">Security</a>,
-              <a href="#profiles-deliverable">Profiles</a>):</dt>
-            <dd>Add normative binding mechanism</dd>
+            <a href="#thing-description-deliverable">Thing Description</a>,
+            <a href="#security-deliverable">Security</a>,
+            <a href="#profiles-deliverable">Profiles</a>):
+          </dt>
+          <dd>Add normative binding mechanism</dd>
           <dt><strong>Protocol Bindings</strong>
             (<a href="#binding:-deliverable">Binding Templates</a>):</dt>
           <dd>Define bindings for specific protocols of interest.</dd>
           <dt><strong>Payload Bindings</strong>
             (<a href="#binding:-deliverable">Binding Templates</a>):</dt>
-            <dd>Define bindings for payload formats of interest.</dd>
+          <dd>Define bindings for payload formats of interest.</dd>
           <dt><strong>Interoperability Profiles</strong>
             (<a href="#profiles-deliverable">Profiles</a>):</dt>
-            <dd>Support out-of-the-box interoperabilty via a profiling mechanism.</dd>
+          <dd>Support out-of-the-box interoperabilty via a profiling mechanism.</dd>
         </dl>
-	</div>
+      </div>
 
-    <section id="section-out-of-scope">
-      <h3 id="out-of-scope">Out of Scope</h3>
+      <section id="section-out-of-scope">
+        <h3 id="out-of-scope">Out of Scope</h3>
         <p>The following features are out of scope, and will not be addressed by this Working group.</p>
 
-	    <dl class="out-of-scope">
-            <dt><strong>Application- and domain-specific metadata vocabularies:</strong></dt>
-            <dd>The Working Group is restricted to work on cross-domain vocabularies.</dd>
-            <dt><strong>APIs and security frameworks specific to particular platforms external to the W3C:</strong></dt>
-            <dd>The scope of the Working Group is restricted to APIs and security frameworks that are applicable across platforms.
+        <dl class="out-of-scope">
+          <dt><strong>Application- and domain-specific metadata vocabularies:</strong></dt>
+          <dd>The Working Group is restricted to work on cross-domain vocabularies.</dd>
+          <dt><strong>APIs and security frameworks specific to particular platforms external to the W3C:</strong></dt>
+          <dd>The scope of the Working Group is restricted to APIs and security frameworks that are applicable across
+            platforms.
             We will not define new security mechanisms but will use existing mechanisms and best practices.</dd>
-            <dt><strong>Modification of protocols:</strong></dt>
-            <dd>If during work on protocol bindings, it becomes apparent that changes are needed to protocols,
-            the Web of Things Working Group will rely on the organization responsible for the protocol to make the changes.
-	    It is out of scope for the Working Group to standardize such changes itself.</dd>
-            </dl>
-        </section>
-
+          <dt><strong>Modification of protocols:</strong></dt>
+          <dd>If during work on protocol bindings, it becomes apparent that changes are needed to protocols,
+            the Web of Things Working Group will rely on the organization responsible for the protocol to make the
+            changes.
+            It is out of scope for the Working Group to standardize such changes itself.</dd>
+        </dl>
       </section>
 
-      <section id="deliverables">
-        <h2>
-          Deliverables
-        </h2>
+    </section>
 
-        <p>Updated document status is available on the <a href="https://www.w3.org/groups/wg/wot/publications">group publication status page</a>.</p>
-        <section id="normative">
-          <h3>
-            Normative Specifications
-          </h3>
-          <p>
-            The Working Group will deliver the following W3C normative specifications:
-          </p>
-          <dl>
-            <dt id="discovery-deliverable" class="spec">Web of Things (WoT) Discovery 1.1</dt>
-            <dd>
-              <p>This specification defines a Discovery process for WoT, and would be a backward-compatible
-                 update to the existing WoT Discovery Specification.</p>
+    <section id="deliverables">
+      <h2>
+        Deliverables
+      </h2>
 
-              <p class="draft-status"><b>Draft state:</b>No draft</p>
-              <p class="milestone"><b>Expected completion:</b> Q3 2024</p>
-              <p><b>Adopted Draft:</b>
+      <p>Updated document status is available on the <a href="https://www.w3.org/groups/wg/wot/publications">group
+          publication status page</a>.</p>
+      <section id="normative">
+        <h3>
+          Normative Specifications
+        </h3>
+        <p>
+          The Working Group will deliver the following W3C normative specifications:
+        </p>
+        <dl>
+          <dt id="discovery-deliverable" class="spec">Web of Things (WoT) Discovery 1.1</dt>
+          <dd>
+            <p>This specification defines a Discovery process for WoT, and would be a backward-compatible
+              update to the existing WoT Discovery Specification.</p>
+
+            <p class="draft-status"><b>Draft state:</b>No draft</p>
+            <p class="milestone"><b>Expected completion:</b> Q3 2024</p>
+            <p><b>Adopted Draft:</b>
               This will be a revision of the current <i>Web of Things (WoT) Discovery</i> specification published
               at <a href="https://www.w3.org/TR/wot-discovery/">https://www.w3.org/TR/wot-discovery/</a>,
               as a Candidate Recommendation on 19 January 2023.</p>
-            </dd>
-            <dt id="binding-deliverable" class="spec">Web of Things (WoT) Binding Templates</dt>
-            <dd>
-              <p>
-                This specification defines the mechanism to bind protocols, payload and media formats, or combination of the two to the Web of Things.
-                The binding mechanism will be a normative document with the following set of registry sections:
-                <ul>
-                  <li>3 registry sections dedicated to stable bindings that reach at least a working draft status</li>
-                  <li>3 registry sections dedicated to experimental bindings that are at least publicly available</li>
-                </ul>
-              </p>
-
-              <p class="draft-status"><b>Draft state:</b>No draft</p>
-              <p class="milestone todo"><b>Expected completion:</b> TBD</p>
-              <p class="todo"><b>Adopted Draft:</b>TBD</p>
-	    </dd>
-          </dl>
-
-        </section>
-
-        <section id="ig-other-deliverables">
-          <h3>
-            Other Deliverables
-          </h3>
-          <p>
-            Other non-normative documents may be created including:
-          </p>
-          <ul>
-            <li id="usecases-deliverable">Use Cases and Requirements;</li>
-            <li id="security-deliverable">Security and Privacy Guidelines (to be published as a W3C Note);</li>
-            <li>Test suite and implementation reports for each specification;</li>
-            <li>Primer or Best Practice documents to support web developers when designing applications.</li>
-	    <li>WoT Scripting API (W3C Note): This document will present a design for a Scripting API that will support exposing and consuming Thing Descriptions while providing a high-level interface to interactions that is independent of protocol. The work will continuously align with the WoT TD specification. Besides these efforts, alignment with the WoT Discovery specification will be the main topic.<br>
-	    <!-- Since we plan to publish an update soon the URL might need to change -->
-	    Draft state: <a href="https://www.w3.org/TR/2020/NOTE-wot-scripting-api-20201124/">Group Note</a>
-	    </li>
-          </ul>
-        </section>
-
-        <section id="timeline">
-          <h3>Timeline</h3>
+          </dd>
+          <dt id="binding-deliverable" class="spec">Web of Things (WoT) Binding Templates</dt>
+          <dd>
+            <p>
+              This specification defines the mechanism to bind protocols, payload and media formats, or combination of
+              the two to the Web of Things.
+              The binding mechanism will be a normative document with the following set of registry sections:
             <ul>
-              <li>June 2023: First teleconference</li>
-              <li>July 2023: First face-to-face meeting</li>
-              <li>September 2023: Requirements and Use Cases for WoT Discovery 1.1</li>
-              <li>January 2024: FPWD for WoT Discovery 1.1</li>
-              <li>August 2024: CR Transition for WoT Discovery 1.1</li>
-              <li>August 2024: Updated publication of WoT Security and Privacy Guidelines as a Note</li>
-              <li>December 2024: PR Transition for WoT Discovery 1.1</li>
-              <li>March 2025: REC Transition for WoT Discovery 1.1</li>
+              <li>3 registry sections dedicated to stable bindings that reach at least a working draft status</li>
+              <li>3 registry sections dedicated to experimental bindings that are at least publicly available</li>
             </ul>
-        </section>
+            </p>
+
+            <p class="draft-status"><b>Draft state:</b>No draft</p>
+            <p class="milestone todo"><b>Expected completion:</b> TBD</p>
+            <p class="todo"><b>Adopted Draft:</b>TBD</p>
+          </dd>
+        </dl>
+
       </section>
 
-	<section id="success-criteria">
-	  <h2>Success Criteria</h2>
+      <section id="ig-other-deliverables">
+        <h3>
+          Other Deliverables
+        </h3>
+        <p>
+          Other non-normative documents may be created including:
+        </p>
+        <ul>
+          <li id="usecases-deliverable">Use Cases and Requirements;</li>
+          <li id="security-deliverable">Security and Privacy Guidelines (to be published as a W3C Note);</li>
+          <li>Test suite and implementation reports for each specification;</li>
+          <li>Primer or Best Practice documents to support web developers when designing applications.</li>
+          <li>WoT Scripting API (W3C Note): This document will present a design for a Scripting API that will support
+            exposing and consuming Thing Descriptions while providing a high-level interface to interactions that is
+            independent of protocol. The work will continuously align with the WoT TD specification. Besides these
+            efforts, alignment with the WoT Discovery specification will be the main topic.<br>
+            <!-- Since we plan to publish an update soon the URL might need to change -->
+            Draft state: <a href="https://www.w3.org/TR/2020/NOTE-wot-scripting-api-20201124/">Group Note</a>
+          </li>
+        </ul>
+      </section>
 
-    <!-- Testing and interop -->
-	  <p>In order to advance to 
-		  <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>, each normative specification is expected to have 
-		  <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least two independent interoperable
-			  implementations</a> of every feature defined in the specification, where
-interoperability can be verified by passing open test suites, and two or
-more implementations interoperating with each other. In order to advance to
-Proposed Recommendation, each normative specification must have an open
-test suite of every feature defined in the specification.</p>
-	  <p>A testing plan will be developed for each specification, starting from the earliest drafts.</p>
-    <p>To promote interoperability, all changes made to specifications 
-      in Candidate Recommendation 
-      or to features that have deployed implementations
-      should have <a href="https://www.w3.org/2019/02/testing-policy.html">tests</a>.  
+      <section id="timeline">
+        <h3>Timeline</h3>
+        <ul>
+          <li>June 2023: First teleconference</li>
+          <li>July 2023: First face-to-face meeting</li>
+          <li>September 2023: Requirements and Use Cases for WoT Discovery 1.1</li>
+          <li>January 2024: FPWD for WoT Discovery 1.1</li>
+          <li>August 2024: CR Transition for WoT Discovery 1.1</li>
+          <li>August 2024: Updated publication of WoT Security and Privacy Guidelines as a Note</li>
+          <li>December 2024: PR Transition for WoT Discovery 1.1</li>
+          <li>March 2025: REC Transition for WoT Discovery 1.1</li>
+        </ul>
+      </section>
+    </section>
 
-    <!-- Horizontal review -->
-    <p>Each specification should contain sections detailing all known security and privacy implications for implementers, Web authors, and end users.</p>
-<!--
+    <section id="success-criteria">
+      <h2>Success Criteria</h2>
+
+      <!-- Testing and interop -->
+      <p>In order to advance to
+        <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed
+          Recommendation</a>, each normative specification is expected to have
+        <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least two independent
+          interoperable
+          implementations</a> of every feature defined in the specification, where
+        interoperability can be verified by passing open test suites, and two or
+        more implementations interoperating with each other. In order to advance to
+        Proposed Recommendation, each normative specification must have an open
+        test suite of every feature defined in the specification.
+      </p>
+      <p>A testing plan will be developed for each specification, starting from the earliest drafts.</p>
+      <p>To promote interoperability, all changes made to specifications
+        in Candidate Recommendation
+        or to features that have deployed implementations
+        should have <a href="https://www.w3.org/2019/02/testing-policy.html">tests</a>.
+
+        <!-- Horizontal review -->
+      <p>Each specification should contain sections detailing all known security and privacy implications for
+        implementers, Web authors, and end users.</p>
+      <!--
 	  <p><i class="todo">For specifications of technologies that directly impact user experience, such as content technologies, as well as protocols and APIs which impact content: </i>
 		Each specification should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and
 		recommendations for maximising accessibility in implementations.</p>
 -->
-	
-	</section>
 
-      <section id="coordination">
-        <h2>Coordination</h2>
-        <p>For all specifications, this Working Group will seek <a href="https://www.w3.org/Guide/documentreview/#how_to_get_horizontal_review">horizontal review</a> for
-          accessibility, internationalization, privacy, and security with the relevant Working and
-          Interest Groups, and with the <a href="https://www.w3.org/2001/tag/" title="Technical Architecture Group">TAG</a>.
-          Invitation for review must be issued during each major standards-track document transition, including
-          <a href="https://www.w3.org/Consortium/Process/#RecsWD" title="First Public Working Draft">FPWD</a>.  The
-          Working Group is encouraged to engage collaboratively with the horizontal review groups throughout development of
-          each specification.  The Working Group is advised to seek a review at least 3 months before first entering
-          <a href="https://www.w3.org/Consortium/Process/#RecsCR" title="Candidate Recommendation">CR</a> and is encouraged
-          to proactively notify the horizontal review groups when major changes occur in a specification following a review.</p>
+    </section>
 
-        <p>Additional technical coordination with the following Groups will be made, per the <a href="https://www.w3.org/Consortium/Process/#WGCharter">W3C Process Document</a>:</p>
+    <section id="coordination">
+      <h2>Coordination</h2>
+      <p>For all specifications, this Working Group will seek <a
+          href="https://www.w3.org/Guide/documentreview/#how_to_get_horizontal_review">horizontal review</a> for
+        accessibility, internationalization, privacy, and security with the relevant Working and
+        Interest Groups, and with the <a href="https://www.w3.org/2001/tag/"
+          title="Technical Architecture Group">TAG</a>.
+        Invitation for review must be issued during each major standards-track document transition, including
+        <a href="https://www.w3.org/Consortium/Process/#RecsWD" title="First Public Working Draft">FPWD</a>. The
+        Working Group is encouraged to engage collaboratively with the horizontal review groups throughout development
+        of
+        each specification. The Working Group is advised to seek a review at least 3 months before first entering
+        <a href="https://www.w3.org/Consortium/Process/#RecsCR" title="Candidate Recommendation">CR</a> and is
+        encouraged
+        to proactively notify the horizontal review groups when major changes occur in a specification following a
+        review.
+      </p>
 
-      	<p class="todo">In addition to the above catch-all reference to horizontal review which includes accessibility review, please check with chairs and staff contacts of the <a href="https://www.w3.org/WAI/APA/">Accessible Platform Architectures Working Group</a> to determine if an additional liaison statement with more specific information about concrete review issues is needed in the list below.</p>
+      <p>Additional technical coordination with the following Groups will be made, per the <a
+          href="https://www.w3.org/Consortium/Process/#WGCharter">W3C Process Document</a>:</p>
 
-        <section>
-          <h3 id="w3c-coordination">W3C Groups</h3>
-          <dl>
-<!--
+      <p class="todo">In addition to the above catch-all reference to horizontal review which includes accessibility
+        review, please check with chairs and staff contacts of the <a href="https://www.w3.org/WAI/APA/">Accessible
+          Platform Architectures Working Group</a> to determine if an additional liaison statement with more specific
+        information about concrete review issues is needed in the list below.</p>
+
+      <section>
+        <h3 id="w3c-coordination">W3C Groups</h3>
+        <dl>
+          <!--
             <dt><a href="https://w3c.github.io/charter-drafts/charter-template.html"><i class="todo">[other name]</i> Working Group</a></dt>
               <dd><i class="todo">[specific nature of liaison]</i></dd>
 -->
-            <dt><a href="https://www.w3.org/community/wot/">Web of Things Community Group</a></dt>
-              <dd>For collaboration on community outreach of the WG reports to increase adoption and implementation, 
-		  as well as collecting feedback from the global community. 
-		  Meetings held in English.
-		  </dd>	
-            <dt><a href="https://www.w3.org/community/wot-jp/">Web of Things Japanese Community Group</a></dt>
-              <dd>For collaboration on community outreach of the WG reports to increase adoption and implementation, 
-		  as well as collecting feedback from the Japanese community. 
-		  Meetings held in Japanese.
-		  </dd>	
-            <dt><a href="https://www.w3.org/groups/ig/wot">Web of Things Interest Group</a></dt>
-	      <dd>For collaboration as outlined in <a href="#scope">Scope</a>.</dd>
-	    <dt><a href="https://www.w3.org/2018/json-ld-wg/">JSON-LD Working Group</a></dt>
-	      <dd>For collaboration on JSON-LD features and WoT use cases.</dd>
-	    <dt><a href="https://www.w3.org/community/exi-next/">Efficient Extensible Interchange Community Group</a></dt>
-	      <dd>In relation to efficient interchange for Thing Descriptions.</dd>
-	    <dt><a href="https://www.w3.org/auto/">Web and Automotive Business &amp; Working Groups</a></dt>
-	      <dd>For collaboration on technologies and requirements relating to connected cars and the Web of Things.</dd>
-	    <dt><a href="https://www.w3.org/2009/dap/">Device and Sensors Working Group</a></dt>
-	      <dd>For coordination on APIs for sensors and actuators.</dd>
-	    <dt><a href="">Decentralized Identifier Working Group</a></dt>
-	      <dd>For coordination on identity management and information lifecycle.</dd>
-	    <dt><a href="https://www.w3.org/web-networks/">Web &amp; Networks Interest Group</a></dt>
-	      <dd>For collaboration on networking and computing technologies on the edge and in the 
-		  cloud when exposing interactions between Things.</dd>
-	    <dt><a href="https://www.w3.org/WAI/APA/">Accessible Platform Architectures Working Group</a></dt>
-	      <dd>For coordination on impact of WoT technologies on accessibility for users with disabilities,
-		  and to support new capabilities that help leverage WoT connectivity and sensor networks
-		  for disability support in public and private spaces.</dd>
-	    <dt><a href="https://www.w3.org/Privacy/">Privacy Interest Group</a></dt>
-	      <dd>In addition to horizontal review, during development of deliverables such
-                  as discovery and information lifecycle that
-                  require the development of a privacy-preserving architecture,
-                  close technical collaboration with the Privacy Interest Group will be needed.</dd>
-	    <dt><a href="https://www.w3.org/community/iotschema/">Schema Extensions for IoT Community Group</a></dt>
-	       <dd>For collaboration on extensions to Schema.org for IoT use cases.</dd>
-          </dl>
+          <dt><a href="https://www.w3.org/community/wot/">Web of Things Community Group</a></dt>
+          <dd>For collaboration on community outreach of the WG reports to increase adoption and implementation,
+            as well as collecting feedback from the global community.
+            Meetings held in English.
+          </dd>
+          <dt><a href="https://www.w3.org/community/wot-jp/">Web of Things Japanese Community Group</a></dt>
+          <dd>For collaboration on community outreach of the WG reports to increase adoption and implementation,
+            as well as collecting feedback from the Japanese community.
+            Meetings held in Japanese.
+          </dd>
+          <dt><a href="https://www.w3.org/groups/ig/wot">Web of Things Interest Group</a></dt>
+          <dd>For collaboration as outlined in <a href="#scope">Scope</a>.</dd>
+          <dt><a href="https://www.w3.org/2018/json-ld-wg/">JSON-LD Working Group</a></dt>
+          <dd>For collaboration on JSON-LD features and WoT use cases.</dd>
+          <dt><a href="https://www.w3.org/community/exi-next/">Efficient Extensible Interchange Community Group</a></dt>
+          <dd>In relation to efficient interchange for Thing Descriptions.</dd>
+          <dt><a href="https://www.w3.org/auto/">Web and Automotive Business &amp; Working Groups</a></dt>
+          <dd>For collaboration on technologies and requirements relating to connected cars and the Web of Things.</dd>
+          <dt><a href="https://www.w3.org/2009/dap/">Device and Sensors Working Group</a></dt>
+          <dd>For coordination on APIs for sensors and actuators.</dd>
+          <dt><a href="">Decentralized Identifier Working Group</a></dt>
+          <dd>For coordination on identity management and information lifecycle.</dd>
+          <dt><a href="https://www.w3.org/web-networks/">Web &amp; Networks Interest Group</a></dt>
+          <dd>For collaboration on networking and computing technologies on the edge and in the
+            cloud when exposing interactions between Things.</dd>
+          <dt><a href="https://www.w3.org/WAI/APA/">Accessible Platform Architectures Working Group</a></dt>
+          <dd>For coordination on impact of WoT technologies on accessibility for users with disabilities,
+            and to support new capabilities that help leverage WoT connectivity and sensor networks
+            for disability support in public and private spaces.</dd>
+          <dt><a href="https://www.w3.org/Privacy/">Privacy Interest Group</a></dt>
+          <dd>In addition to horizontal review, during development of deliverables such
+            as discovery and information lifecycle that
+            require the development of a privacy-preserving architecture,
+            close technical collaboration with the Privacy Interest Group will be needed.</dd>
+          <dt><a href="https://www.w3.org/community/iotschema/">Schema Extensions for IoT Community Group</a></dt>
+          <dd>For collaboration on extensions to Schema.org for IoT use cases.</dd>
+        </dl>
 
-<!--
+        <!--
           <p class="issue"><b>Note:</b> Do not list horizontal groups here, only specific WGs relevant to your work.</p>
           <p class="issue"><b>Note:</b> Do not bury normative text inside the liaison section.
             Instead, put it in the scope section.</p>
 -->
-        </section>
-
-        <section>
-          <h3 id="external-coordination">External Organizations</h3>
-	  <p>
-            To succeed in establishing inter-platform standards,
-            W3C needs to coordinate with IoT alliances and standards development organizations.
-          </p>
-          <p>
-            List of new liaisons we want to form
-          </p>
-          <dl>
-            <dt> <a href="https://opcfoundation.org/">OPC Foundation</a>
-              <dd>
-                For coordination on the development of the OPC UA Binding for the W3C Web of Things via the joint working group.
-                A Memorandum of Understanding (MoU) / Multi-Organization Cooperation Agreement (MOCA) will be considered in order to establish a formal relationship.
-              </dd>
-            </dt>
-            <dt> <a href="https://industrialdigitaltwin.org/en/">Industrial Digital Twin Association</a>
-              <dd>
-                For coordination on the use of TDs and Binding Templates in the Asset Interface Description (AID) Submodel for the Asset Administration (AAS) Specification.
-                Additionally, the AAS Submodels can be used for Digital Nameplate and Digital Product Passport of products that the European Commission is demanding each product to supply.
-                Also see <a href="https://github.com/w3c/wot/issues/978#issuecomment-1359830278">the related GitHub comment</a>.
-              </dd>
-            </dt>
-            <dt> <a href="https://www.ashrae.org/">ASHRAE</a>
-              <dd>
-                For coordination on the development of the BACnet (ASHRAE 135-2020) Binding for the W3C Web of Things .
-              </dd>
-            </dt>
-            <dt><a href="https://github.com/Azure/opendigitaltwins-dtdl">Azure/Microsoft/OpenDigitalTwins DTDL</a></dt>
-	                <dd>
-              For coordination on aligning the DTDL with the W3C WoT TD. 
-              NOTE: Microsoft is not an external organization so I am not sure how this should be put. The language itself is not limited to be used in Azure
-            </dd>
-            <dt> <a href="https://www.digitaltwinconsortium.org/">Digital Twin Consortium</a>
-              <dd>
-                TBD.
-              </dd>
-            </dt>
-            <dt> <a href="https://www.ietf.org/">IETF</a>
-              <dd>
-                TBD.
-              </dd>
-            </dt>
-            <dt> <a href="https://csa-iot.org/">Connectivity Standards Alliance (CSA)</a>
-            <dd>
-              TBD. However, a Matter Protocol Binding would be of interest.
-            </dd>
-            </dt>
-            <dt> <a href="https://onedm.org/">One Data Model</a>
-            <dd>
-              For coordination of SDF with the TD.
-            </dd>
-            </dt>
-            <dt> <a href="https://www.ogc.org/">Open Geospatial Consortium (OGC)</a>
-            <dd>
-              TBD. However, geolocation related collaboration is of interest.
-            </dd>
-            </dt>
-            <dt> <a href="https://www.conexxus.org/">Conexxus</a>
-            <dd>
-              TBD. However, retail use cases exploration is probably what we are doing.
-            </dd>
-            </dt>
-          </dl>
-          <p>
-            List from previous charter to be verified. Add them to the list above if agreed.
-            There is also a wiki page linked but that page has not been updated since 2018.
-          </p>
-
-          <p>The following list provides examples of organizations with which the WoT Working Group
-	              has already had significant coordination during the period of the first charter. 
-            A <a href="https://www.w3.org/WoT/IG/wiki/How_does_W3C_compare_to_other_organizations">longer list</a> 
-            is available on the Interest Group wiki.
-          </p>
-          <dl>
-            <dt><a href="https://datatracker.ietf.org/doc/charter-irtf-t2trg/">IRTF Thing to Thing Research Group</a></dt>
-            <dd>For coordination of matters of mutual interest in relation to the Web of Things, such as data modelling, discovery, directory services, and IoT semantics.</dd>
-            <dt><a href="https://openconnectivity.org">Open Connectivity Foundation</a></dt>
-            <dd>For collaboration on integrating OCF based platforms within the Web of Things, including platform metadata and approaches for enabling semantic interoperability, and end to end security across platforms.</dd>
-            <dt><a href="https://echonet.jp/english/">ECHONET Consortium</a></dt>
-            <dd>For collaboration on integrating ECHONET Consortium based platforms within the Web of Things, including platform metadata and approaches for enabling semantic interoperability, and end to end security across platforms.</dd>
-            <dt><a href="http://www.iiconsortium.org">Industrial Internet Consortium</a></dt>
-            <dd>For collaboration on testbeds and on gathering user requirements for the Web of Things.</dd>
-            <dd>NOTE: They have changed their name to Industry IoT Consortium</dd>
-            <dt><a href="http://www.plattform-i40.de/I40/Navigation/EN/Home/home.html">Plattform Industrie 4.0</a></dt>
-            <dd>For collaboration on use cases and requirements for smart manufacturing, including semantic interoperability and end to end security across platforms.
-              NOTE: IDTA Liaison proposed above can and should replace this. Plattform Industrie 4.0 is not active like before.
-            </dd>
-            <dt><a href="http://www.onem2m.org">oneM2M</a></dt>
-            <dd>For collaboration on integrating M2M based platforms within the Web of Things, including platform metadata and approaches for enabling semantic interoperability, and end to end security across platforms.</dd>
-            <dt><a href="https://www.etsi.org">ETSI</a></dt>
-            <dd>For collaboration on IoT, M2M, security, and semantic interoperability.</dd>
-            <dt><a href="https://www.omaspecworks.org">OMA SpecWorks</a></dt>
-            <dd>For collaboration on integrating LWM2M based platforms with the Web of Things.</dd>
-            <dt><a href="http://www.opengeospatial.org/">Open Geospatial Consortium</a></dt>
-            <dd>For coordination on the OGC SensorThings API and location metadata.</dd>
-            <dt><a href="http://www.gsma.com">GSMA</a></dt>
-            <dd>For coordination in respect to the interests of Network Operators.</dd>
-            <dt><a href="https://www.gs1.org/">GS1</a></dt>
-            <dd>For coordination on identifiers and discovery.</dd>
-            <dt><a href="https://www.eclass.eu/en.html">ECLASS</a></dt>
-            <dd>For collaboration and coordination of the technical realization of the use of ECLASS in the W3C Thing Description.</dd>
-            <dt><a href="https://aioti.eu/">AIOTI WG03</a></dt>
-            <dd>For coordination with the Alliance for Internet of Things Innovation, Working Group 3 (standardisation), in respect to use cases, requirements, and semantic interoperability.</dd>
-          </dl>
-          <dl>
-            <dt><a href="https://w3c.github.io/charter-drafts/charter-template.html"><i class="todo">[other name]</i> Working Group</a></dt>
-            <dd><i class="todo">[specific nature of liaison]</i></dd>
-          </dl>
-        </section>
       </section>
 
+      <section>
+        <h3 id="external-coordination">External Organizations</h3>
+        <p>
+          To succeed in establishing inter-platform standards, W3C needs to coordinate with IoT alliances and standards
+          development organizations.
+          A <a href="https://www.w3.org/WoT/IG/wiki/How_does_W3C_compare_to_other_organizations">longer list</a>
+          is available on the Interest Group wiki that includes cooperations partners from former Web of Things
+          charters.
+        </p>
+        <p>
+          List of active and new liaisons:
+        </p>
+        <dl>
+          <dt> <a href="https://opcfoundation.org/">OPC Foundation</a>
+          <dd>
+            For coordination on the development of the OPC UA Binding for the W3C Web of Things.
+            A Memorandum of Understanding (MoU) / Multi-Organization Cooperation Agreement (MOCA) will be considered in
+            order to establish a formal relationship.
+          </dd>
+          </dt>
+          <dt><a href="https://echonet.jp/english/">ECHONET Consortium</a>
+          <dd>For collaboration on integrating ECHONET Consortium based platforms within the Web of Things, including
+            platform metadata and approaches for enabling semantic interoperability, and end to end security across
+            platforms.</dd>
+          </dt>
+          <dt> <a href="https://industrialdigitaltwin.org/en/">Industrial Digital Twin Association</a>
+          <dd>
+            For coordination on the use of TDs and Binding Templates in the Asset Interface Description (AID) submodel
+            for the Asset Administration (AAS) specification.
+            Additionally, the AAS submodels can be used for Digital Nameplate (DNP) and Product Carbon Footprint (PCF)
+            to form the Digital Product Passport (DPP) of products
+            that the European Commission is demanding each product to supply (DPP4.0).
+            Also see <a href="https://github.com/w3c/wot/issues/978#issuecomment-1359830278">the related GitHub
+              comment</a>.
+          </dd>
+          </dt>
+          <dt> <a href="https://www.ashrae.org/">ASHRAE</a>
+          <dd>
+            For coordination on the development of the BACnet (ASHRAE 135-2020) Binding for the W3C Web of Things .
+          </dd>
+          </dt>
+          <dt> <a href="https://www.ietf.org/">IETF</a>
+          <dd>
+            Coordinate common interests related to Internet of Things and Web of Things, e.g., issues such as
+            serialization, security, and trustworthiness.
+          </dd>
+          </dt>
+          <dt><a href="https://datatracker.ietf.org/doc/charter-irtf-t2trg/">IRTF Thing to Thing Research Group</a>
+          <dd>For coordination of matters of mutual interest in relation to the Web of Things, such as data modelling,
+            discovery, directory services, and IoT semantics.
+          </dd>
+        </dl>
+        <dt> <a href="https://csa-iot.org/">Connectivity Standards Alliance (CSA)</a>
+        <dd>
+          To coordinate smart home use cases and to develop a potential Matter Protocol Binding.
+        </dd>
+        </dt>
+        <dt> <a href="https://onedm.org/">One Data Model</a>
+        <dd>
+          For coordination of Semantic Definition Format (SDF) with the Thing Description.
+        </dd>
+        </dt>
+        <dt> <a href="https://www.ogc.org/">Open Geospatial Consortium (OGC)</a>
+        <dd>
+          To coordinate geolocation use cases and potential geo-based definitions for Thing Models and Thing
+          Descriptions.
+        </dd>
+        </dt>
+        <dt> <a href="https://www.conexxus.org/">Conexxus</a>
+        <dd>
+          To coordinate retail use cases and show case in PlugFests.
+        </dd>
+        </dt>
+        <dt><a href="https://www.eclass.eu/en.html">ECLASS</a>
+        <dd>For collaboration and coordination of the technical realization of the use of ECLASS in the W3C Thing
+          Description.</dd>
+        </dt>
+        </dl>
 
-
-      <section class="participation">
-        <h2 id="participation">
-          Participation
-        </h2>
-        <p>
-          To be successful, this Working Group is expected to have 6 or more active participants for its duration, including representatives from the key implementors of this specification, and active Editors and Test Leads for each specification. The Chairs, specification Editors, and Test Leads are expected to contribute half of a working day per week towards the Working Group. There is no minimum requirement for other Participants.
-        </p>
-        <p>
-          The group encourages questions, comments and issues on its public mailing lists and document repositories, as described in <a href="https://w3c.github.io/charter-drafts/charter-template.html#communication">Communication</a>.
-        </p>
-        <p>
-          The group also welcomes non-Members to contribute technical submissions for consideration upon their agreement to the terms of the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a>.
-        </p>
-        <p>Participants in the group are required (by the <a href="https://www.w3.org/Consortium/Process/#ParticipationCriteria">W3C Process</a>) to follow the
-          W3C <a href="https://www.w3.org/Consortium/cepc/">Code of Ethics and Professional Conduct</a>.</p>
       </section>
+    </section>
 
 
 
-      <section id="communication">
-        <h2>
-          Communication
-        </h2>
-        <p id="public">
-          Technical discussions for this Working Group are conducted in <a href="https://www.w3.org/Consortium/Process/#confidentiality-levels">public</a>: the meeting minutes from teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue tracking will be conducted in a manner that can be both read and written to by the general public. Working Drafts and Editor's Drafts of specifications will be developed in public repositories and may permit direct public contribution requests.
+    <section class="participation">
+      <h2 id="participation">
+        Participation
+      </h2>
+      <p>
+        To be successful, this Working Group is expected to have 6 or more active participants for its duration,
+        including representatives from the key implementors of this specification, and active Editors and Test Leads for
+        each specification. The Chairs, specification Editors, and Test Leads are expected to contribute half of a
+        working day per week towards the Working Group. There is no minimum requirement for other Participants.
+      </p>
+      <p>
+        The group encourages questions, comments and issues on its public mailing lists and document repositories, as
+        described in <a
+          href="https://w3c.github.io/charter-drafts/charter-template.html#communication">Communication</a>.
+      </p>
+      <p>
+        The group also welcomes non-Members to contribute technical submissions for consideration upon their agreement
+        to the terms of the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a>.
+      </p>
+      <p>Participants in the group are required (by the <a
+          href="https://www.w3.org/Consortium/Process/#ParticipationCriteria">W3C Process</a>) to follow the
+        W3C <a href="https://www.w3.org/Consortium/cepc/">Code of Ethics and Professional Conduct</a>.</p>
+    </section>
+
+
+
+    <section id="communication">
+      <h2>
+        Communication
+      </h2>
+      <p id="public">
+        Technical discussions for this Working Group are conducted in <a
+          href="https://www.w3.org/Consortium/Process/#confidentiality-levels">public</a>: the meeting minutes from
+        teleconference and face-to-face meetings will be archived for public review, and technical discussions and issue
+        tracking will be conducted in a manner that can be both read and written to by the general public. Working
+        Drafts and Editor's Drafts of specifications will be developed in public repositories and may permit direct
+        public contribution requests.
         The meetings themselves are not open to public participation, however.
-        </p>
-        <p>
-          Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) will be available from the <a href="https://www.w3.org/WoT/">Web of Things (WoT) Working Group home page.</a>
-        </p>
-        <p>
-          Most Web of Things (WoT) Working Group teleconferences will focus on discussion of particular specifications, and will be conducted on an as-needed basis.  However, one teleconference will be held weekly to coordinate activities among the task forces responsible for each specification.
-        </p>
-        <p>
-          This group primarily conducts its technical work  
-          on <a id="public-github" href="https://github.com/w3c/wot">GitHub issues</a>, using 
-          a main repository for general topics and more specific repositories for individual specifications.
-          The public is invited to review, discuss and contribute to this work.
-        </p>
-        <p>
-          The group may use a Member-confidential mailing list for administrative purposes and, at the discretion of the Chairs and members of the group, for member-only discussions in special cases when a participant requests such a discussion.
-        </p>
-      </section>
+      </p>
+      <p>
+        Information about the group (including details about deliverables, issues, actions, status, participants, and
+        meetings) will be available from the <a href="https://www.w3.org/WoT/">Web of Things (WoT) Working Group home
+          page.</a>
+      </p>
+      <p>
+        Most Web of Things (WoT) Working Group teleconferences will focus on discussion of particular specifications,
+        and will be conducted on an as-needed basis. However, one teleconference will be held weekly to coordinate
+        activities among the task forces responsible for each specification.
+      </p>
+      <p>
+        This group primarily conducts its technical work
+        on <a id="public-github" href="https://github.com/w3c/wot">GitHub issues</a>, using
+        a main repository for general topics and more specific repositories for individual specifications.
+        The public is invited to review, discuss and contribute to this work.
+      </p>
+      <p>
+        The group may use a Member-confidential mailing list for administrative purposes and, at the discretion of the
+        Chairs and members of the group, for member-only discussions in special cases when a participant requests such a
+        discussion.
+      </p>
+    </section>
 
 
 
-      <section id="decisions">
-        <h2>
-          Decision Policy
-        </h2>
-        <p>
-          This group will seek to make decisions through consensus and due process, per the <a href="https://www.w3.org/Consortium/Process/#Consensus">W3C Process Document (section 5.2.1, Consensus)</a>. Typically, an editor or other participant makes an initial proposal, which is then refined in discussion with members of the group and other reviewers, and consensus emerges with little formal voting being required.</p>
-        <p>
-           However, if a decision is necessary for timely progress and consensus is not achieved after careful consideration of the range of views presented, the Chairs may call for a group vote and record a decision along with any objections.
-        </p>
-        <p>
-          To afford asynchronous decisions and organizational deliberation, any resolution (including publication decisions) taken in a face-to-face meeting or teleconference will be considered provisional.
+    <section id="decisions">
+      <h2>
+        Decision Policy
+      </h2>
+      <p>
+        This group will seek to make decisions through consensus and due process, per the <a
+          href="https://www.w3.org/Consortium/Process/#Consensus">W3C Process Document (section 5.2.1, Consensus)</a>.
+        Typically, an editor or other participant makes an initial proposal, which is then refined in discussion with
+        members of the group and other reviewers, and consensus emerges with little formal voting being required.</p>
+      <p>
+        However, if a decision is necessary for timely progress and consensus is not achieved after careful
+        consideration of the range of views presented, the Chairs may call for a group vote and record a decision along
+        with any objections.
+      </p>
+      <p>
+        To afford asynchronous decisions and organizational deliberation, any resolution (including publication
+        decisions) taken in a face-to-face meeting or teleconference will be considered provisional.
 
-          A call for consensus (CfC) will be issued for all resolutions (for example, via email, GitHub issue or web-based survey), with a response period from one week to 10 working days, depending on the chair's evaluation of the group consensus on the issue.
+        A call for consensus (CfC) will be issued for all resolutions (for example, via email, GitHub issue or web-based
+        survey), with a response period from one week to 10 working days, depending on the chair's evaluation of the
+        group consensus on the issue.
 
-          If no objections are raised by the end of the response period, the resolution will be considered to have consensus as a resolution of the Working Group.
-        </p>
-        <p>
-          All decisions made by the group should be considered resolved unless and until new information becomes available or unless reopened at the discretion of the Chairs or the Director.
-        </p>
-        <p>
-          This charter is written in accordance with the <a href="https://www.w3.org/Consortium/Process/#Votes">W3C Process Document (Section 5.2.3, Deciding by Vote)</a> and includes no voting procedures beyond what the Process Document requires.
-        </p>
-      </section>
-
-
-
-      <section id="patentpolicy">
-
-        <h2>
-          Patent Policy
-        </h2>
-        <p>
-          This Working Group operates under the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a> (Version of 15 September 2020). To promote the widest adoption of Web standards, W3C seeks to issue Web specifications that can be implemented, according to this policy, on a Royalty-Free basis.
-
-          For more information about disclosure obligations for this group, please see the <a href="https://www.w3.org/groups/wg/[shortname]/ipr">licensing information</a>.
-        </p>
-
-      </section>
+        If no objections are raised by the end of the response period, the resolution will be considered to have
+        consensus as a resolution of the Working Group.
+      </p>
+      <p>
+        All decisions made by the group should be considered resolved unless and until new information becomes available
+        or unless reopened at the discretion of the Chairs or the Director.
+      </p>
+      <p>
+        This charter is written in accordance with the <a href="https://www.w3.org/Consortium/Process/#Votes">W3C
+          Process Document (Section 5.2.3, Deciding by Vote)</a> and includes no voting procedures beyond what the
+        Process Document requires.
+      </p>
+    </section>
 
 
 
-      <section id="licensing">
-        <h2>Licensing</h2>
-        <p>This Working Group will use the 
-          <a href="https://www.w3.org/Consortium/Legal/copyright-software">W3C Software and Document license</a> 
-          for all its deliverables.</p>
+    <section id="patentpolicy">
 
-      </section>
+      <h2>
+        Patent Policy
+      </h2>
+      <p>
+        This Working Group operates under the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent
+          Policy</a> (Version of 15 September 2020). To promote the widest adoption of Web standards, W3C seeks to issue
+        Web specifications that can be implemented, according to this policy, on a Royalty-Free basis.
+
+        For more information about disclosure obligations for this group, please see the <a
+          href="https://www.w3.org/groups/wg/[shortname]/ipr">licensing information</a>.
+      </p>
+
+    </section>
 
 
 
-      <section id="about">
-        <h2>
-          About this Charter
-        </h2>
-        <p>
-          This charter has been created according to <a href="https://www.w3.org/Consortium/Process/#GAGeneral">section 3.4</a> of the <a href="https://www.w3.org/Consortium/Process/">Process Document</a>. In the event of a conflict between this document or the provisions of any charter and the W3C Process, the W3C Process shall take precedence.
-        </p>
+    <section id="licensing">
+      <h2>Licensing</h2>
+      <p>This Working Group will use the
+        <a href="https://www.w3.org/Consortium/Legal/copyright-software">W3C Software and Document license</a>
+        for all its deliverables.
+      </p>
 
-	      <!-- Not needed for "new" charter 
+    </section>
+
+
+
+    <section id="about">
+      <h2>
+        About this Charter
+      </h2>
+      <p>
+        This charter has been created according to <a href="https://www.w3.org/Consortium/Process/#GAGeneral">section
+          3.4</a> of the <a href="https://www.w3.org/Consortium/Process/">Process Document</a>. In the event of a
+        conflict between this document or the provisions of any charter and the W3C Process, the W3C Process shall take
+        precedence.
+      </p>
+
+      <!-- Not needed for "new" charter 
         <section id="history">
           <h3>
             Charter History
@@ -796,37 +846,41 @@ test suite of every feature defined in the specification.</p>
         </section>
 -->
 
-        <section id="changelog">
-          <h3>Change log</h3>
+      <section id="changelog">
+        <h3>Change log</h3>
 
-          <!-- Use this section for changes _after_ the charter was approved by the Director. -->
-          <p>Changes to this document are documented in this section.</p>
-          <!--
+        <!-- Use this section for changes _after_ the charter was approved by the Director. -->
+        <p>Changes to this document are documented in this section.</p>
+        <!--
           <dl id='changes'>
             <dt>YYYY-MM-DD</dt>
             <dd>[changes]]</dd>
           </dl>
           -->
-        </section>
       </section>
-    </main>
+    </section>
+  </main>
 
+  <hr>
+
+  <footer>
+    <address>
+      <i class="todo"><a href="mailto:">[team contact name]</a></i>
+    </address>
+
+    <p class="copyright">Copyright © 2023</i> <a href="https://www.w3.org/">World Wide Web Consortium</a>.<br>
+      <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
+      <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+      <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
+      <a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"
+        title="W3C Software and Document Notice and License">permissive document license</a> rules apply.
+    </p>
     <hr>
+    <p><span class="todo"><a href="https://github.com/w3c/wot-charter-drafts">Yes, it's on GitHub!</a>.</span></p>
+  </footer>
 
-    <footer>
-      <address>
-        <i class="todo"><a href="mailto:">[team contact name]</a></i>
-      </address>
 
-<p class="copyright">Copyright © 2023</i> <a href="https://www.w3.org/">World Wide Web Consortium</a>.<br>
-  <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
-  <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
-  <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
-      <a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" title="W3C Software and Document Notice and License">permissive document license</a> rules apply.</p>
-      <hr>
-      <p><span class="todo"><a href="https://github.com/w3c/wot-charter-drafts">Yes, it's on GitHub!</a>.</span></p>
-    </footer>
 
-  
+</body>
 
-</body></html>
+</html>


### PR DESCRIPTION
my proposal is to remove non-active cooperation partners and move them to the [wiki page](https://www.w3.org/WoT/IG/wiki/How_does_W3C_compare_to_other_organizations), this includes:

- OCF
- Industrial Internet Consortium
- Plattform Industrie 4.0 --> new IDTA liaison would represent this
-  oneM2M
- ETSI
- OMA SpecWorks 
- GSMA
- GS1
- AIOTI WG03 

What is the status of ITU-T ?


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/pull/43.html" title="Last updated on Feb 16, 2023, 11:51 AM UTC (787b6b7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/43/41ebaea...787b6b7.html" title="Last updated on Feb 16, 2023, 11:51 AM UTC (787b6b7)">Diff</a>