### PR TITLE
Update wot-wg-2023-draft.html: Adding digital twins

### DIFF
--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -296,10 +296,26 @@
           <dd>Define bindings for specific protocols and payloads of interest while focusing to support ecosystems.</dd>
           <dt><strong>Interoperability Profiles</strong>
             (<a href="#profiles-deliverable">Profiles</a>):</dt>
-            <dd>Support out-of-the-box interoperabilty via a profiling mechanism.</dd>
-	        <dt><strong>Digital Twins</strong>
-            (<a href="#digital-twin-deliverable">Profiles</a>, <a href="#thing-description-deliverable">Thing Description</a>):</dt>
-            <dd>Enable using WoT for describing digital twins and their behavior.</dd>
+          <dd>
+	    Support out-of-the-box interoperabilty via a profiling mechanism.
+	  </dd>
+	  <dt>
+	    <strong>Digital Twins</strong>
+            (<a href="#profiles-deliverable">Profiles</a>, 
+	     <a href="#thing-description-deliverable">Thing Description</a>):
+	  </dt>
+          <dd>
+	    Enable using WoT for describing digital twins, i.e. virtual things that are an abstraction of real world devices and services.
+	  </dd>
+	  <dt>
+	    <strong>Behavioral Description</strong>
+            (<a href="#profiles-deliverable">Profiles</a>, 
+	     <a href="#thing-description-deliverable">Thing Description</a>):
+	  </dt>
+          <dd>
+	    Formal description of the behavior of things, 
+	    thing models and digital twins.
+	  </dd>
         </dl>
       </div>
 

--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -308,6 +308,10 @@
           <dt><strong>Interoperability Profiles</strong>
             (<a href="#profiles-deliverable">Profiles</a>):</dt>
             <dd>Support out-of-the-box interoperabilty via a profiling mechanism.</dd>
+	  <dt><strong>Digital Twins</strong>
+            (<a href="#digital-twin-deliverable">Profiles</a>, <a href="#thing-description-deliverable">Thing Description</a>):</dt>
+            <dd>Enable using WoT for describing digital twins and their behavior.</dd>
+
         </dl>
 	</div>
 


### PR DESCRIPTION



<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/pull/46.html" title="Last updated on Feb 22, 2023, 9:19 AM UTC (ac18248)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/46/071e115...ac18248.html" title="Last updated on Feb 22, 2023, 9:19 AM UTC (ac18248)">Diff</a>