### PR TITLE
Remove PING and A11Y groups

### DIFF
--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -497,15 +497,6 @@
 		  cloud when exposing interactions between Things.</dd>
 	    <dt><a href="https://www.w3.org/web-networks/">Spatial Data on the Web Working Group</a></dt>
 	      <dd>For collaboration on geolocation, in conjunction with the Open Geospatial Consortium.</dd>
-	    <dt><a href="https://www.w3.org/WAI/APA/">Accessible Platform Architectures Working Group</a></dt>
-	      <dd>For coordination on impact of WoT technologies on accessibility for users with disabilities,
-		  and to support new capabilities that help leverage WoT connectivity and sensor networks
-		  for disability support in public and private spaces.</dd>
-	    <dt><a href="https://www.w3.org/Privacy/">Privacy Interest Group</a></dt>
-	      <dd>In addition to horizontal review, during development of deliverables such
-                  as discovery and information lifecycle that
-                  require the development of a privacy-preserving architecture,
-                  close technical collaboration with the Privacy Interest Group will be needed.</dd>
 	    <dt><a href="https://www.w3.org/community/iotschema/">Schema Extensions for IoT Community Group</a></dt>
 	       <dd>For collaboration on extensions to Schema.org for IoT use cases.</dd>
           </dl>


### PR DESCRIPTION
Resolves #45 

Option 1/2 (pick just one): This PR removes the mention of the Privacy and Accessibility groups altogether.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/pull/49.html" title="Last updated on Feb 20, 2023, 6:40 PM UTC (049767e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/49/071e115...049767e.html" title="Last updated on Feb 20, 2023, 6:40 PM UTC (049767e)">Diff</a>