### PR TITLE
Modify A11Y group desc

### DIFF
--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -500,7 +500,7 @@
 	    <dt><a href="https://www.w3.org/WAI/APA/">Accessible Platform Architectures Working Group</a></dt>
 	      <dd>In addition to horizontal review, coordination on impact of WoT technologies on accessibility,
 		  and support for new capabilities that help leverage WoT connectivity and sensor networks
-		  for disability support in public and private spaces is needed.</dd>
+		  for accessibility support in public and private spaces is needed.</dd>
 	    <dt><a href="https://www.w3.org/Privacy/">Privacy Interest Group</a></dt>
 	      <dd>In addition to horizontal review, during development of deliverables such
                   as discovery and information lifecycle that

--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -498,7 +498,7 @@
 	    <dt><a href="https://www.w3.org/web-networks/">Spatial Data on the Web Working Group</a></dt>
 	      <dd>For collaboration on geolocation, in conjunction with the Open Geospatial Consortium.</dd>
 	    <dt><a href="https://www.w3.org/WAI/APA/">Accessible Platform Architectures Working Group</a></dt>
-	      <dd>In addition to horizontal review, coordination on impact of WoT technologies on accessibility for users with disabilities,
+	      <dd>In addition to horizontal review, coordination on impact of WoT technologies on accessibility,
 		  and support for new capabilities that help leverage WoT connectivity and sensor networks
 		  for disability support in public and private spaces is needed.</dd>
 	    <dt><a href="https://www.w3.org/Privacy/">Privacy Interest Group</a></dt>

--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -498,9 +498,9 @@
 	    <dt><a href="https://www.w3.org/web-networks/">Spatial Data on the Web Working Group</a></dt>
 	      <dd>For collaboration on geolocation, in conjunction with the Open Geospatial Consortium.</dd>
 	    <dt><a href="https://www.w3.org/WAI/APA/">Accessible Platform Architectures Working Group</a></dt>
-	      <dd>For coordination on impact of WoT technologies on accessibility for users with disabilities,
-		  and to support new capabilities that help leverage WoT connectivity and sensor networks
-		  for disability support in public and private spaces.</dd>
+	      <dd>In addition to horizontal review, coordination on impact of WoT technologies on accessibility for users with disabilities,
+		  and support for new capabilities that help leverage WoT connectivity and sensor networks
+		  for disability support in public and private spaces is needed.</dd>
 	    <dt><a href="https://www.w3.org/Privacy/">Privacy Interest Group</a></dt>
 	      <dd>In addition to horizontal review, during development of deliverables such
                   as discovery and information lifecycle that


### PR DESCRIPTION
Resolves #45 

Option 2/2 (pick just one): This adds "In addition to horizontal review" as well as a verb to the description, so it is parallel to the one for Privacy.  This emphasizes that this is a conscious decision to go above and beyond the wide review requirements.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/pull/50.html" title="Last updated on Feb 21, 2023, 1:30 PM UTC (2beef75)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/50/071e115...2beef75.html" title="Last updated on Feb 21, 2023, 1:30 PM UTC (2beef75)">Diff</a>