### PR TITLE
Remove APA Coord To Do

### DIFF
--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -458,11 +458,6 @@
       <p>Additional technical coordination with the following Groups will be made, per the <a
           href="https://www.w3.org/Consortium/Process/#WGCharter">W3C Process Document</a>:</p>
 
-      <p class="todo">In addition to the above catch-all reference to horizontal review which includes accessibility
-        review, please check with chairs and staff contacts of the <a href="https://www.w3.org/WAI/APA/">Accessible
-          Platform Architectures Working Group</a> to determine if an additional liaison statement with more specific
-        information about concrete review issues is needed in the list below.</p>
-
       <section>
         <h3 id="w3c-coordination">W3C Groups</h3>
         <dl>


### PR DESCRIPTION
- Remove "to do" paragraph checking stating that we should include an additional APA coordination in addition to horizontal review
- After PR #45 is resolved