### PR TITLE
Move IG mention to collaboration section

### DIFF
--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -88,14 +88,6 @@
       These building blocks should complement and enhance the use of existing standards, and allow WoT to
       be used within other ecosystems and communities.
       This reduces the initial friction for adoption and supports further industry adoption.
-      <span class="todo">This Working Group Charter covers those aspects that the
-        <a href="http://www.w3.org/groups/ig/wot">Web of Things Interest Group</a>
-        <a href="https://www.w3.org/2021/12/wot-ig-2021.html">(charter here)</a>
-        believes are mature enough to progress to W3C Recommendations.
-      </span>
-      <!-- This is not true anymore and can be removed. IG does not write any reports other than use cases. 
-        All reports that specify a WoT building block, even informative ones, are done by the WG.
-        Also, there is a repeating statement below -->
       <!-- the link to the group is ALWAYS that available from https://www.w3.org/groups/wg or https://www.w3.org/groups/ig because each group page can then point to a different homepage, but not the other way around. -->
 
     <div class="noprint">
@@ -181,9 +173,8 @@
       <h2>Motivation and Background</h2>
       <!-- Brief background of landscape, technology, and relationship to the Web, users, developers, implementers, and industry. -->
       <p>As a continuation of the work in <a href="https://www.w3.org/2022/07/wot-wg-2022.html">the previous charter</a>, 
-        this working group is tasked with the standardization or extension of the building blocks
-        identified by the use cases resulting from the work of <a href="https://www.w3.org/groups/ig/wot">the Web of
-        Things Interest Group</a> (IG) as being important to advance the Web of Things.
+        this working group is tasked with the standardization or extension of the building blocks identified as being 
+        important to advance the Web of Things.
         The WoT building blocks are intended to complement and integrate to existing and emerging IoT standards using Web technologies. 
         As a result, the building blocks focus on enabling cross-platform and cross-domain interoperability in the IoT.
 <!--
@@ -428,7 +419,17 @@
 		  Meetings held in Japanese.
 		  </dd>	
             <dt><a href="https://www.w3.org/groups/ig/wot">Web of Things Interest Group</a></dt>
-	      <dd>For collaboration as outlined in <a href="#scope">Scope</a>.</dd>
+	      <dd><span class="todo">This Working Group Charter covers those aspects that the
+          <a href="http://www.w3.org/groups/ig/wot">Web of Things Interest Group</a>
+          <a href="https://www.w3.org/2021/12/wot-ig-2021.html">(charter here)</a>
+          believes are mature enough to progress to W3C Recommendations.
+        </span>
+        <p>As a continuation of the work in <a href="https://www.w3.org/2022/07/wot-wg-2022.html">the previous charter</a>,
+          this working group is tasked with the standardization or extension of the building blocks
+          identified by the use cases resulting from the work of <a href="https://www.w3.org/groups/ig/wot">the Web of
+            Things Interest Group</a> (IG) as being important to advance the Web of Things.
+        </p>
+            </dd>
 	    <dt><a href="https://www.w3.org/2018/json-ld-wg/">JSON-LD Working Group</a></dt>
 	      <dd>For collaboration on JSON-LD features and WoT use cases.</dd>
 	    <dt><a href="https://www.w3.org/community/exi-next/">Efficient Extensible Interchange Community Group</a></dt>

--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -423,12 +423,11 @@
           <a href="http://www.w3.org/groups/ig/wot">Web of Things Interest Group</a>
           <a href="https://www.w3.org/2021/12/wot-ig-2021.html">(charter here)</a>
           believes are mature enough to progress to W3C Recommendations.
+          As a continuation of the work in <a href="https://www.w3.org/2022/07/wot-wg-2022.html">the previous charter</a>,
+            this working group is tasked with the standardization or extension of the building blocks
+            identified by the use cases resulting from the work of <a href="https://www.w3.org/groups/ig/wot">the Web of
+              Things Interest Group</a> (IG) as being important to advance the Web of Things.
         </span>
-        <p>As a continuation of the work in <a href="https://www.w3.org/2022/07/wot-wg-2022.html">the previous charter</a>,
-          this working group is tasked with the standardization or extension of the building blocks
-          identified by the use cases resulting from the work of <a href="https://www.w3.org/groups/ig/wot">the Web of
-            Things Interest Group</a> (IG) as being important to advance the Web of Things.
-        </p>
             </dd>
 	    <dt><a href="https://www.w3.org/2018/json-ld-wg/">JSON-LD Working Group</a></dt>
 	      <dd>For collaboration on JSON-LD features and WoT use cases.</dd>

--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -402,33 +402,32 @@
         information about concrete review issues is needed in the list below.</p>
 
       <section>
-        <h3 id="w3c-coordination">W3C Groups</h3>
+        <h3 id="w3c-coordination">WoT-related W3C Groups</h3>
+        <dt><a href="https://www.w3.org/groups/ig/wot">Web of Things Interest Group</a></dt>
+        <dd><span class="todo">This Working Group Charter covers those aspects that the
+            <a href="http://www.w3.org/groups/ig/wot">Web of Things Interest Group</a>
+            <a href="https://www.w3.org/2021/12/wot-ig-2021.html">(charter here)</a>
+            believes are mature enough to progress to W3C Recommendations.
+            As a continuation of the work in <a href="https://www.w3.org/2022/07/wot-wg-2022.html">the previous charter</a>,
+              this working group is tasked with the standardization or extension of the building blocks
+              identified by the use cases resulting from the work of <a href="https://www.w3.org/groups/ig/wot">the Web of
+                Things Interest Group</a> (IG) as being important to advance the Web of Things.
+          </span>
+            </dd>
+        <dt><a href="https://www.w3.org/community/wot/">Web of Things Community Group</a></dt>
+        <dd>For collaboration on community outreach of the WG reports to increase adoption and implementation, as well as 
+          collecting feedback from the global community. Meetings held in English.
+        </dd>	
+        <dt><a href="https://www.w3.org/community/wot-jp/">Web of Things Japanese Community Group</a></dt>
+        <dd>For collaboration on community outreach of the WG reports to increase adoption and implementation, as well as 
+          collecting feedback from the Japanese community. Meetings held in Japanese.
+        </dd>	
+        <h3 id="w3c-coordination">Other W3C Groups</h3>
         <dl>
           <!--
             <dt><a href="https://w3c.github.io/charter-drafts/charter-template.html"><i class="todo">[other name]</i> Working Group</a></dt>
               <dd><i class="todo">[specific nature of liaison]</i></dd>
           -->
-            <dt><a href="https://www.w3.org/community/wot/">Web of Things Community Group</a></dt>
-              <dd>For collaboration on community outreach of the WG reports to increase adoption and implementation, 
-		  as well as collecting feedback from the global community. 
-		  Meetings held in English.
-		  </dd>	
-            <dt><a href="https://www.w3.org/community/wot-jp/">Web of Things Japanese Community Group</a></dt>
-              <dd>For collaboration on community outreach of the WG reports to increase adoption and implementation, 
-		  as well as collecting feedback from the Japanese community. 
-		  Meetings held in Japanese.
-		  </dd>	
-            <dt><a href="https://www.w3.org/groups/ig/wot">Web of Things Interest Group</a></dt>
-	      <dd><span class="todo">This Working Group Charter covers those aspects that the
-          <a href="http://www.w3.org/groups/ig/wot">Web of Things Interest Group</a>
-          <a href="https://www.w3.org/2021/12/wot-ig-2021.html">(charter here)</a>
-          believes are mature enough to progress to W3C Recommendations.
-          As a continuation of the work in <a href="https://www.w3.org/2022/07/wot-wg-2022.html">the previous charter</a>,
-            this working group is tasked with the standardization or extension of the building blocks
-            identified by the use cases resulting from the work of <a href="https://www.w3.org/groups/ig/wot">the Web of
-              Things Interest Group</a> (IG) as being important to advance the Web of Things.
-        </span>
-            </dd>
 	    <dt><a href="https://www.w3.org/2018/json-ld-wg/">JSON-LD Working Group</a></dt>
 	      <dd>For collaboration on JSON-LD features and WoT use cases.</dd>
 	    <dt><a href="https://www.w3.org/community/exi-next/">Efficient Extensible Interchange Community Group</a></dt>


### PR DESCRIPTION
I am doing a very simple move of the text without changing any content so that we avoid a lengthy discussion on this particular point. Later on, I will make another PR to actually change the content and explain what the relationship is. Given that #65 was made during the call on what we seem to agree on, this should be easily mergable.

fixes #65


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/pull/66.html" title="Last updated on Mar 27, 2023, 11:45 AM UTC (a61f867)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/66/8dbe03d...a61f867.html" title="Last updated on Mar 27, 2023, 11:45 AM UTC (a61f867)">Diff</a>