### PR TITLE
Use parallel verb structure for scope categories

### DIFF
--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -208,7 +208,7 @@
       <p>During this charter, the Working Group would work on the following:</p>
 
         <dl>
-          <dt><strong>Updates to existing specifications</strong>:</dt>
+          <dt><strong>Update Existing Specifications</strong>:</dt>
           <dd>The WG will add new features and address issues discovered during implementation of already published specifications. 
             Unlike the last charter, these would not be limited to backward-compatible updates.
           </dd>
@@ -236,7 +236,7 @@
           <dt><strong>Improve Security and Privacy</strong>:</dt>
            <dd>Define reusable, external security vocabularies, simplify the use of security schemes, and define and onboarding
           lifecycle process to establish mutual trust and identification, and other work as appropriate.</dd>
-          <dt><strong>New Use Cases</strong>:
+          <dt><strong>Support New Use Cases</strong>:
           </dt>
           <dd>Address the functional requirements of new use cases, such as Digital Twins.</dd>
         </dl>


### PR DESCRIPTION
Resolves #68 by using parallel structures starting with a verb and consistent capitalization for all scope category headers.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-charter-drafts/pull/70.html" title="Last updated on Feb 28, 2023, 2:46 PM UTC (577e15e)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/70/04cdada...mmccool:577e15e.html" title="Last updated on Feb 28, 2023, 2:46 PM UTC (577e15e)">Diff</a>