### PR TITLE
Remove reusable connections term from charter

### DIFF
--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -230,7 +230,7 @@
           </dt>
           <dd>
             The WG will work on increasing the descriptive power of TDs to allow using them in more use cases. This includes
-            describing dynamic resources, stateful interactions, historical values (timeseries), repeating payloads, both static and dynamic
+            describing dynamic resources, historical values (timeseries), repeating payloads, both static and dynamic
             geolocation information, manageable actions and more precise definitions of data schemas for each type of operation.
           </dd>
           <dt><strong>Improve Security and Privacy</strong>:</dt>

--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -230,7 +230,7 @@
           </dt>
           <dd>
             The WG will work on increasing the descriptive power of TDs to allow using them in more use cases. This includes
-            describing dynamic resources, statefull interactions, historical values (timeseries), repeating payloads, both static and dynamic
+            describing dynamic resources, stateful interactions, historical values (timeseries), repeating payloads, both static and dynamic
             geolocation information, manageable actions and more precise definitions of data schemas for each type of operation.
           </dd>
           <dt><strong>Improve Security and Privacy</strong>:</dt>

--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -230,7 +230,7 @@
           </dt>
           <dd>
             The WG will work on increasing the descriptive power of TDs to allow using them in more use cases. This includes
-            describing dynamic resources, reusable connections, historical values (timeseries), repeating payloads, both static and dynamic
+            describing dynamic resources, statefull interactions, historical values (timeseries), repeating payloads, both static and dynamic
             geolocation information, manageable actions and more precise definitions of data schemas for each type of operation.
           </dd>
           <dt><strong>Improve Security and Privacy</strong>:</dt>


### PR DESCRIPTION
If you want to keep a detailed list of possible features implemented as an improvement of the descriptiveness of TDs, I think using `stateful interactions` captures better the summary of the different discussions that we had. I am talking about stateful interactions because currently, we treat each operation as stateless meaning that the Consumer can invoke one operation without performing any initial setup or keeping track of how many times he called that ops. Note this is also true for subscribe ops (exceptions could be unsubscribe ops and the recently added async actions but we treated them similarly to the other ops causing issues). 

With stateful interactions, we can capture protocols that need to keep track of the state of the communication channel between the two parties (like persistent connections or even complex rendez-vous). On the other hand, it is a more ambitious objective to achieve.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/pull/73.html" title="Last updated on Mar 1, 2023, 5:25 PM UTC (19c35fe)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/73/04cdada...19c35fe.html" title="Last updated on Mar 1, 2023, 5:25 PM UTC (19c35fe)">Diff</a>