### PR TITLE
Propose Chairs

### DIFF
--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -142,7 +142,7 @@
               Chairs
             </th>
             <td>
-              <i class="todo">[chair name] (affiliation)</i>
+              Sebastian Kaebisch (Siemens) and Michael McCool (Intel)
             </td>
           </tr>
           <tr>

--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -142,7 +142,7 @@
               Chairs
             </th>
             <td>
-              Sebastian Kaebisch (Siemens) and Michael McCool (Intel)
+              <i class="todo">Sebastian Kaebisch (Siemens) and Michael McCool (Intel) (PROPOSED)</i>
             </td>
           </tr>
           <tr>


### PR DESCRIPTION
Resolves https://github.com/w3c/wot-charter-drafts/issues/71

- list Sebastian Kaebisch and Michael McCool as chairs (in that order, reversing the order from the last charter to balance things out)
- Mark as "(PROPOSED)"
- Mark as "todo" to be consistent with proposed dates


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-charter-drafts/pull/75.html" title="Last updated on Mar 2, 2023, 1:11 PM UTC (8cc5491)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/75/d2d1c25...mmccool:8cc5491.html" title="Last updated on Mar 2, 2023, 1:11 PM UTC (8cc5491)">Diff</a>