### PR TITLE
Comment out note from template

### DIFF
--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -170,11 +170,13 @@
         </tbody>
       </table>
 
+<!--
       <p class="issue"><b>Note:</b> The <a href="https://www.w3.org/Consortium/Process/#WGCharter">W3C Process
           Document</a> requires “The level of confidentiality of the group's proceedings and deliverables”; however, it
         does not mandate where this appears. Since all W3C Working Groups should be chartered as public, this notice has
         been moved from the essentials table to the <a
           href="https://w3c.github.io/charter-drafts/charter-template.html#public">communication section</a>.</p>
+-->
     </div>
 
     <div id="background" class="background">


### PR DESCRIPTION
There was a note right after the table, just before the Background section, that was not about the WoT WG but about the structure of the template.  This PR comments it out.

This PR should be considered editorial cleanup.  It does not affect content relative to the WoT WG.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-charter-drafts/pull/76.html" title="Last updated on Mar 2, 2023, 1:16 PM UTC (5f5d066)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/76/d2d1c25...mmccool:5f5d066.html" title="Last updated on Mar 2, 2023, 1:16 PM UTC (5f5d066)">Diff</a>