### PR TITLE
Use Generic Spec Names

### DIFF
--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -301,7 +301,7 @@
               at <a href="https://www.w3.org/TR/wot-discovery/">https://www.w3.org/TR/wot-discovery/</a>,
               as a Candidate Recommendation on 19 January 2023.</p>
             </dd>
-            <dt id="thing-description-deliverable" class="spec">Thing Description</dt>
+            <dt id="thing-description-deliverable" class="spec">Thing Description (Update)</dt>
             <dd>
               <p>
                 This specification defines the Web of Things Thing Description information model and its JSON-LD serialization. 

--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -275,7 +275,12 @@
       </h2>
 
       <p>Updated document status is available on the <a href="https://www.w3.org/groups/wg/wot/publications">group
-          publication status page</a>.</p>
+          publication status page</a>.
+      The specification names given below are not exact titles as
+      we are currently discussing how to best manage versioning and how to
+      reflect this in the title of documents.
+      Final titles will include "Web of Things".
+      </p>
       <section id="normative">
         <h3>
           Normative Specifications
@@ -284,7 +289,7 @@
           The Working Group will deliver the following W3C normative specifications:
         </p>
         <dl>
-          <dt id="discovery-deliverable" class="spec">Web of Things (WoT) Discovery (Update)</dt>
+          <dt id="discovery-deliverable" class="spec">Discovery (Update)</dt>
           <dd>
             <p>This specification defines a Discovery process for WoT, and would be a backward-compatible
               update to the existing WoT Discovery Specification.</p>
@@ -296,7 +301,7 @@
               at <a href="https://www.w3.org/TR/wot-discovery/">https://www.w3.org/TR/wot-discovery/</a>,
               as a Candidate Recommendation on 19 January 2023.</p>
             </dd>
-            <dt id="thing-description-deliverable" class="spec">Web of Things (WoT) Thing Description</dt>
+            <dt id="thing-description-deliverable" class="spec">Thing Description</dt>
             <dd>
               <p>
                 This specification defines the Web of Things Thing Description information model and its JSON-LD serialization. 
@@ -311,7 +316,7 @@
               as a Candidate Recommendation on 19 January 2023.</p>
           </dl>
 
-          <dt id="profiles-deliverable" class="spec">Web of Things (WoT) Profile</dt>
+          <dt id="profiles-deliverable" class="spec">Profile</dt>
           <dd>
             <p>
               This specification defines a profiling mechanism to enable out-of-the-box interoperability between
@@ -321,7 +326,7 @@
             <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/wot-profile/">Working Draft</a></p>
             <p class="milestone"><b>Expected completion:</b>1 November 2023</p>
           </dd>
-          <dt id="profiles-deliverable-next" class="spec">Web of Things (WoT) Profile (Update)</dt>
+          <dt id="profiles-deliverable-next" class="spec">Profile (Update)</dt>
           <dd>
             <p>
               This specification is an update to the WoT Profile specification, with


### PR DESCRIPTION
Resolves https://github.com/w3c/wot-charter-drafts/issues/38

- Use "generic" spec names like "Discovery", "Thing Description", etc. for each deliverable
- Add a paragraph saying that titles will be finalized later, as we are discussing how to manage versioning, but will include "Web of Things".


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-charter-drafts/pull/79.html" title="Last updated on Mar 8, 2023, 11:57 AM UTC (2c413ec)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/79/d2d1c25...mmccool:2c413ec.html" title="Last updated on Mar 8, 2023, 11:57 AM UTC (2c413ec)">Diff</a>