### PR TITLE
Remove onboarding from scope summary

### DIFF
--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -234,8 +234,9 @@
             geolocation information, manageable actions and more precise definitions of data schemas for each type of operation.
           </dd>
           <dt><strong>Improve Security and Privacy</strong>:</dt>
-           <dd>Define reusable, external security vocabularies, simplify the use of security schemes, and define and onboarding
-          lifecycle process to establish mutual trust and identification, and other work as appropriate.</dd>
+           <dd>Define reusable external security vocabularies, simplify the use of security schemes, 
+            and other work as appropriate.
+          </dd>
           <dt><strong>Support New Use Cases</strong>:
           </dt>
           <dd>Address the functional requirements of new use cases, such as Digital Twins.</dd>


### PR DESCRIPTION
- This removes mention of "onboarding" from the charter scope summary
- This is to address some concerns raised (see issue https://github.com/w3c/wot-charter-drafts/issues/67) about whether onboarding is something we should do in WoT or should be done in another group, whether we need some exploratory work first, etc.
- The exact wording of the text in the scope section after this PR means we still *could* do it, this PR just means we would not be *committing* to do it in the charter itself.
- I would still like to merge PR #77 (and refine it) so we have a clear definition of what problem needs to be solved and a potential solution to that problem, even if we later spin off that work into the IG or another group.  I have my doubts that some other group will solve this problem for us if we do nothing.
- While I was at it I got rid of a comma after "reusable" that was unnecessary and potentially confusing.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-charter-drafts/pull/81.html" title="Last updated on Mar 6, 2023, 2:19 PM UTC (d70a9a1)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/81/6b96197...mmccool:d70a9a1.html" title="Last updated on Mar 6, 2023, 2:19 PM UTC (d70a9a1)">Diff</a>