### PR TITLE
Add Architecture as an informative deliverable

### DIFF
--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -350,6 +350,11 @@
           Other non-normative documents may be created including:
         </p>
         <ul>
+          <li id="architecture-deliverable">Architecture (Update): This specification defines the Web of Things architecture,
+            terminology, fundamental concepts, architecture and deployment patterns, and horizontal security and privacy considerations.
+            It introduces and gives an overview of the family of WoT building block specifications described 
+            in the normative deliverables section.
+          </li>
           <li id="usecases-deliverable">Use Cases and Requirements;</li>
           <li id="security-deliverable">Security and Privacy Guidelines (to be published as a W3C Note);</li>
           <li>Test suite and implementation reports for each specification;</li>


### PR DESCRIPTION
As alternative of #82


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/pull/85.html" title="Last updated on Mar 8, 2023, 4:35 PM UTC (f673408)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/85/0dae730...f673408.html" title="Last updated on Mar 8, 2023, 4:35 PM UTC (f673408)">Diff</a>