### PR TITLE
Remove normative deliverable mention from bindings

### DIFF
--- a/wot-wg-2023-details.html
+++ b/wot-wg-2023-details.html
@@ -132,53 +132,53 @@
           <dt>
             <a href="#http-binding-workitem"><strong>HTTP Protocol Binding</strong></a> (Binding Templates):
           </dt>
-          <dd>Add normative HTTP binding</dd>
+          <dd>Add HTTP binding</dd>
           <dt>
             <a href="#coap-binding-workitem"><strong>CoAP Protocol Binding</strong></a> (Binding Templates):
           </dt>
-          <dd>Add normative CoAP binding</dd>
+          <dd>Add CoAP binding</dd>
           <dt>
             <a href="#mqtt-binding-workitem"><strong>MQTT Protocol Binding</strong></a> (Binding Templates):
           </dt>
-          <dd>Add normative MQTT binding</dd>
+          <dd>Add MQTT binding</dd>
           <dt>
             <a href="#modbus-binding-workitem"><strong>Modbus Protocol Binding</strong></a> (Binding Templates):
           </dt>
-          <dd>Add normative Modbus binding</dd>
+          <dd>Add Modbus binding</dd>
           <dt>
             <a href="#bacnet-binding-workitem"><strong>BACnet Protocol Binding</strong></a> (Binding Templates):
           </dt>
-          <dd>Add normative BACnet binding</dd>
+          <dd>Add BACnet binding</dd>
           <dt>
             <a href="#opcua-binding-workitem"><strong>OPC UA Protocol Binding</strong></a> (Binding Templates):
           </dt>
-          <dd>Add normative OPC UA binding</dd>
+          <dd>Add OPC UA binding</dd>
           <dt>
             <a href="#grpc-binding-workitem"><strong>gRPC Protocol Binding</strong></a> (Binding Templates):
           </dt>
-          <dd>Add normative gRPC binding</dd>
+          <dd>Add gRPC binding</dd>
           <dt>
             <a href="#json-binding-workitem"><strong>JSON Payload Binding</strong></a> (Binding Templates):
           </dt>
-          <dd>Add normative JSON binding</dd>
+          <dd>Add JSON binding</dd>
           <dt>
             <a href="#cbor-binding-workitem"><strong>CBOR Payload Binding</strong></a> (Binding Templates):
           </dt>
-          <dd>Add normative CBOR binding</dd>
+          <dd>Add CBOR binding</dd>
           <dt>
             <a href="#xml-binding-workitem"><strong>XML Payload Binding</strong></a> (Binding Templates):
           </dt>
-          <dd>Add normative XML binding</dd>
+          <dd>Add XML binding</dd>
           <dt>
             <a href="#cloudevents-binding-workitem"><strong>CloudEvents Payload Binding</strong></a> (Binding
             Templates):
           </dt>
-          <dd>Add normative CloudEvents binding</dd>
+          <dd>Add CloudEvents binding</dd>
           <dt>
             <a href="#echonet-binding-workitem"><strong>ECHONET Lite Web API Combination Binding</strong></a> (Binding
             Templates):
           </dt>
-          <dd>Add normative ECHONET Lite Web API binding</dd>
+          <dd>Add ECHONET Lite Web API binding</dd>
         </dl>
       </dd>
       <dt><strong>Other</strong>:</dt>


### PR DESCRIPTION
This is just removing the "normative" word from binding templates in the details document