### PR TITLE
Add consumer description topics

### DIFF
--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -239,6 +239,10 @@
            <dd>Define reusable external security vocabularies, simplify the use of security schemes, 
             and other work as appropriate.
           </dd>
+          <dt><strong>Evaluate Consumer Descriptions</strong>:
+          </dt>
+            <dd>Experiment and possibly specify a way to describe Consumers of Thing Descriptions.
+            </dd>
           <dt><strong>Support New Use Cases</strong>:
           </dt>
           <dd>Address the functional requirements of new use cases, such as Digital Twins.</dd>
@@ -364,6 +368,9 @@
           <li>Binding Documents for Specific Protocol, Payload and Ecosystems (W3C Notes): These documents will take 
             the requirements specified in <a href="binding-deliverable">Web of Things (WoT) Binding Templates</a> and 
             specify how protocols and payload formats should be used to allow integration of specific classes of IoT systems and ecosystems.
+          </li>
+          <li>Consumer Description (W3C Note): Based on the experiences that the WG will gather, this document will allow
+            specifying what the Consumer expects a Thing to do, filling the gap in describing more complete WoT systems.
           </li>
         </ul>
       </section>


### PR DESCRIPTION
As mentioned by @mlagally , a description of what the Thing should do for a given Consumer is missing. We have discussed this internally a bit and there can be a real use of it. However, I am not sure to if we should commit to a REC deliverable since we lack experience in this direction. We can do more experimentation on this and publish a note that becomes a REC later on.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/pull/89.html" title="Last updated on Mar 13, 2023, 10:25 AM UTC (6761c54)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/89/0dae730...6761c54.html" title="Last updated on Mar 13, 2023, 10:25 AM UTC (6761c54)">Diff</a>