### PR TITLE
Add pre-announced CfC to decision process

### DIFF
--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -672,7 +672,7 @@
         In some cases, resolutions can be announced and proposed in advance, by circulating an email to the group
         with concrete proposed text for the resolution.  In these cases, the announcement can be considered the 
         call for consensus (CfC) and when the resolution is made by the group, it can be considered final, at the 
-        discretion of the chair, if sufficent time (5 to 10 working days, at the discretion of the chair, as above)
+        discretion of the chairs, if sufficient time (5 to 10 working days, at the discretion of the chairs, as above)
         has been allowed for asynchronous input.  
         This process will be followed especially for publication decisions which are then effective immediately.
       </p>

--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -662,7 +662,7 @@
         both proposed and taken in a face-to-face meeting or teleconference will be considered provisional.
 
         A call for consensus (CfC) will be issued for all such resolutions (for example, via email, GitHub issue or web-based
-        survey), with a response period from 5 to 8 working days, depending on the chair's evaluation of the
+        survey), with a response period from 5 to 10 working days, depending on the chair's evaluation of the
         group consensus on the issue.
 
         If no objections are raised by the end of the response period, the resolution will be considered to have
@@ -672,7 +672,7 @@
         In some cases, resolutions can be announced and proposed in advance, by circulating an email to the group
         with concrete proposed text for the resolution.  In these cases, the announcement can be considered the 
         call for consensus (CfC) and when the resolution is made by the group, it can be considered final, at the 
-        discretion of the chair, if sufficent time (5 to 8 working days, at the discretion of the chair, as above)
+        discretion of the chair, if sufficent time (5 to 10 working days, at the discretion of the chair, as above)
         has been allowed for asynchronous input.  
         This process will be followed especially for publication decisions which are then effective immediately.
       </p>

--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -662,7 +662,7 @@
         both proposed and taken in a face-to-face meeting or teleconference will be considered provisional.
 
         A call for consensus (CfC) will be issued for all such resolutions (via email)
-        with a response period from 5 to 10 working days, depending on the chairs' evaluation of the
+        with a response period from 5 to 10 working days, depending on the Chairs' evaluation of the
         group consensus on the issue.
 
         If no objections are raised by the end of the response period, the resolution will be considered to have

--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -662,7 +662,7 @@
         both proposed and taken in a face-to-face meeting or teleconference will be considered provisional.
 
         A call for consensus (CfC) will be issued for all such resolutions (via email)
-        survey), with a response period from 5 to 10 working days, depending on the chair's evaluation of the
+        with a response period from 5 to 10 working days, depending on the chair's evaluation of the
         group consensus on the issue.
 
         If no objections are raised by the end of the response period, the resolution will be considered to have

--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -658,15 +658,23 @@
         with any objections.
       </p>
       <p>
-        To afford asynchronous decisions and organizational deliberation, any resolution (including publication
-        decisions) taken in a face-to-face meeting or teleconference will be considered provisional.
+        To afford asynchronous decisions and organizational deliberation, resolutions 
+        both proposed and taken in a face-to-face meeting or teleconference will be considered provisional.
 
-        A call for consensus (CfC) will be issued for all resolutions (for example, via email, GitHub issue or web-based
-        survey), with a response period from one week to 10 working days, depending on the chair's evaluation of the
+        A call for consensus (CfC) will be issued for all such resolutions (for example, via email, GitHub issue or web-based
+        survey), with a response period from 5 to 8 working days, depending on the chair's evaluation of the
         group consensus on the issue.
 
         If no objections are raised by the end of the response period, the resolution will be considered to have
         consensus as a resolution of the Working Group.
+      </p>
+      <p>
+        In some cases, resolutions can be announced and proposed in advance, by circulating an email to the group
+        with concrete proposed text for the resolution.  In these cases, the announcement can be considered the 
+        call for consensus (CfC) and when the resolution is made by the group, it can be considered final, at the 
+        discretion of the chair, if sufficent time (5 to 8 working days, at the discretion of the chair, as above)
+        has been allowed for asynchronous input.  
+        This process will be followed especially for publication decisions which are then effective immediately.
       </p>
       <p>
         All decisions made by the group should be considered resolved unless and until new information becomes available

--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -662,7 +662,7 @@
         both proposed and taken in a face-to-face meeting or teleconference will be considered provisional.
 
         A call for consensus (CfC) will be issued for all such resolutions (via email)
-        with a response period from 5 to 10 working days, depending on the chair's evaluation of the
+        with a response period from 5 to 10 working days, depending on the chairs' evaluation of the
         group consensus on the issue.
 
         If no objections are raised by the end of the response period, the resolution will be considered to have

--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -661,7 +661,7 @@
         To afford asynchronous decisions and organizational deliberation, resolutions 
         both proposed and taken in a face-to-face meeting or teleconference will be considered provisional.
 
-        A call for consensus (CfC) will be issued for all such resolutions (for example, via email, GitHub issue or web-based
+        A call for consensus (CfC) will be issued for all such resolutions (via email)
         survey), with a response period from 5 to 10 working days, depending on the chair's evaluation of the
         group consensus on the issue.
 

--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -672,7 +672,7 @@
         In some cases, resolutions can be announced and proposed in advance, by circulating an email to the group
         with concrete proposed text for the resolution.  In these cases, the announcement can be considered the 
         call for consensus (CfC) and when the resolution is made by the group, it can be considered final, at the 
-        discretion of the chairs, if sufficient time (5 to 10 working days, at the discretion of the chairs, as above)
+        discretion of the Chairs, if sufficient time (5 to 10 working days, at the discretion of the Chairs, as above)
         has been allowed for asynchronous input.  
         This process will be followed especially for publication decisions which are then effective immediately.
       </p>


### PR DESCRIPTION
Resolves #28 

- Adds option for "pre-announced CfC" especially for publications (which is what we have been doing)
- Resolutions which are *proposed* in meetings are provisional.
- Resolutions which are *pre-announced* (with concrete text!) can be effective immediately
- The text "week to 10 working days" was ambiguous.  Is that a week of working days, e.g. 7 working days, or 5 working days?  Changed to "5 to 10 working days" (which is one to two weeks, including weekends).

Note that if we follow what is written here, we have to make the following changes:
- After meetings, we need to send around an annoucement of any "provisional" resolutions taken, along with a deadline for comments (a CfC)
- We have to have *concrete* text for proposed resolutions *in advance* of meetings circulated similarily.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/mmccool/wot-charter-drafts/pull/91.html" title="Last updated on Mar 15, 2023, 12:55 PM UTC (6106267)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/91/a5cffe1...mmccool:6106267.html" title="Last updated on Mar 15, 2023, 12:55 PM UTC (6106267)">Diff</a>