### PR TITLE
Protocol Bindings Option 2 - Common protocol bindings in profiles

### DIFF
--- a/wot-wg-2023-details.html
+++ b/wot-wg-2023-details.html
@@ -124,61 +124,60 @@
         </dl>
       </dd>
       <dt>
-        <strong>Protocol and Payload Bindings</strong> (<a href="#binding:-deliverable">Binding Templates</a>):
+        <strong>Protocol Vocabularies and Payload Serializations</strong>:
       </dt>
       <dd>
-        Define bindings for specific protocols and payloads of interest while focusing to support ecosystems.
+        Define vocabularies for describing custom protocol bindings, serialization formats for payloads, and 
+        mappings of WoT to existing platforms and ecosystems.
         <dl>
           <dt>
-            <a href="#http-binding-workitem"><strong>HTTP Protocol Binding</strong></a> (Binding Templates):
+            <a href="#http-protocol-vocabulary-workitem"><strong>HTTP Protocol Vocabulary</strong></a>:
           </dt>
-          <dd>Add normative HTTP binding</dd>
+          <dd>Specify an HTTP protocol binding vocabulary.</dd>
           <dt>
-            <a href="#coap-binding-workitem"><strong>CoAP Protocol Binding</strong></a> (Binding Templates):
+            <a href="#coap-protocol-vocabulary-workitem"><strong>CoAP Protocol Vocabulary</strong></a>:
           </dt>
-          <dd>Add normative CoAP binding</dd>
+          <dd>Specify a CoAP protocol binding vocabulary.</dd>
           <dt>
-            <a href="#mqtt-binding-workitem"><strong>MQTT Protocol Binding</strong></a> (Binding Templates):
+            <a href="#mqtt-protocol-vocabulary-workitem"><strong>MQTT Protocol Vocabulary</strong></a>:
           </dt>
-          <dd>Add normative MQTT binding</dd>
+          <dd>ASpecify an MQTT protocol binding vocabulary.</dd>
           <dt>
-            <a href="#modbus-binding-workitem"><strong>Modbus Protocol Binding</strong></a> (Binding Templates):
+            <a href="#modbus-protocol-vocabulary-workitem"><strong>Modbus Protocol Vocabulary</strong></a>:
           </dt>
-          <dd>Add normative Modbus binding</dd>
+          <dd>Specify a Modbus protocol binding vocabulary.</dd>
           <dt>
-            <a href="#bacnet-binding-workitem"><strong>BACnet Protocol Binding</strong></a> (Binding Templates):
+            <a href="#bacnet-protocol-vocabulary-workitem"><strong>BACnet Protocol Vocabulary</strong></a>:
           </dt>
-          <dd>Add normative BACnet binding</dd>
+          <dd>Specify a BACnet protocol binding vocabulary.</dd>
           <dt>
-            <a href="#opcua-binding-workitem"><strong>OPC UA Protocol Binding</strong></a> (Binding Templates):
+            <a href="#opcua-protocol-vocabulary-workitem"><strong>OPC UA Protocol Vocabulary</strong></a>:
           </dt>
-          <dd>Add normative OPC UA binding</dd>
+          <dd>Specify an OPC UA protocol binding vocabulary.</dd>
           <dt>
-            <a href="#grpc-binding-workitem"><strong>gRPC Protocol Binding</strong></a> (Binding Templates):
+            <a href="#grpc-protocol-vocabulary-workitem"><strong>gRPC Protocol Vocabulary</strong></a>:
           </dt>
-          <dd>Add normative gRPC binding</dd>
+          <dd>Specify a gRPC protocol binding vocabulary.</dd>
           <dt>
-            <a href="#json-binding-workitem"><strong>JSON Payload Binding</strong></a> (Binding Templates):
+            <a href="#json-payload-serialization-workitem"><strong>JSON Payload Serialization</strong></a>:
           </dt>
-          <dd>Add normative JSON binding</dd>
+          <dd>Specify a JSON payload serialization.</dd>
           <dt>
-            <a href="#cbor-binding-workitem"><strong>CBOR Payload Binding</strong></a> (Binding Templates):
+            <a href="#cbor-payload-serialization-workitem"><strong>CBOR Payload Serialization</strong></a>:
           </dt>
-          <dd>Add normative CBOR binding</dd>
+          <dd>Specify a CBOR payload serialization.</dd>
           <dt>
-            <a href="#xml-binding-workitem"><strong>XML Payload Binding</strong></a> (Binding Templates):
+            <a href="#xml-payload-serialization-workitem"><strong>XML Payload Serialization</strong></a>:
           </dt>
-          <dd>Add normative XML binding</dd>
+          <dd>Specify an XML payload serialization.</dd>
           <dt>
-            <a href="#cloudevents-binding-workitem"><strong>CloudEvents Payload Binding</strong></a> (Binding
-            Templates):
+            <a href="#cloudevents-payload-serialization-workitem"><strong>CloudEvents Payload Serialization</strong></a>:
           </dt>
-          <dd>Add normative CloudEvents binding</dd>
+          <dd>Specify a CloudEvents payload serialization.</dd>
           <dt>
-            <a href="#echonet-binding-workitem"><strong>ECHONET Lite Web API Combination Binding</strong></a> (Binding
-            Templates):
+            <a href="#echonet-platform-mapping-workitem"><strong>ECHONET Lite Web API Platform Mapping</strong></a>:
           </dt>
-          <dd>Add normative ECHONET Lite Web API binding</dd>
+          <dd>Specify an ECHONET Lite Web API platform mapping.</dd>
         </dl>
       </dd>
       <dt><strong>Other</strong>:</dt>
@@ -460,82 +459,86 @@
     </section>
     <section>
       <h2 id="binding-mechanism-workitem">Binding Mechanism</h2>
-      <p>The current mechanism for how a protocol or payload binding should happen is largely informative with some
+      <p>The current mechanism for how a protocol binding or payload serialization should happen is largely informative with some
       normative text in different deliverables. The WG will consolidate the explanation of the mechanism and explain it
       in further detail.</p>
     </section>
     <section>
-      <h2 id="http-binding-workitem">HTTP Protocol Binding</h2>
-      <p>The WG will work on the current HTTP Protocol Binding that is split also into the TD specification in order to
-      publish it as a standalone normative document. This will reference the HTTP in RDF ontology, introduce default
-      values and describe the terms associated with the behavior of Things regarding the usage of the HTTP.</p>
+      <h2 id="http-protocol-vocabulary-workitem">HTTP Protocol Vocabulary</h2>
+      <p>The WG will work on an HTTP Protocol Vocabulary specification (based on the current HTTP Binding Template 
+        document) which provides a vocabulary for providing custom HTTP protocol bindings in Thing Descriptions. This 
+        will reference the HTTP in RDF ontology, introduce default values and define terms for describing the behaviour 
+        of Things using HTTP.</p>
     </section>
     <section>
-      <h2 id="coap-binding-workitem">CoAP Protocol Binding</h2>
-      <p>The WG will work on the current Modbus Protocol Binding in order to publish it as a standalone normative
-      document. This will include a CoAP ontology, introduce default values and describe the terms associated with the
-      behavior of Things regarding the usage of the CoAP.</p>
+      <h2 id="coap-protocol-vocabulary-workitem">CoAP Protocol Vocabulary</h2>
+      <p>The WG will work on a CoAP Protocol Vocabulary specification (based on the current CoAP Binding Template 
+        document) which provides a vocabulary for describing custom CoAP protocol bindings in Thing Descriptions.
+        This will include a CoAP ontology, introduce default values and define terms for describing the behaviour 
+        of Things using CoAP.</p>
     </section>
     <section>
-      <h2 id="mqtt-binding-workitem">MQTT Protocol Binding</h2>
-      <p>The WG will work on the current MQTT Protocol Binding in order to publish it as a standalone normative
-      document. This will include a MQTT ontology, introduce default values and describe the terms associated with the
-      behavior of Things and Brokers regarding the usage of the MQTT.</p>
+      <h2 id="mqtt-protocol-vocabulary-workitem">MQTT Protocol Vocabulary</h2>
+      <p>The WG will work on an MQTT Protocol Vocabulary specification (based on the current MQTT Binding Template 
+        document) which provides a vocabulary for describing custom MQTT protocol bindings in Thing Descriptions.
+        This will include an MQTT ontology, introduce default values and define terms for describing the behaviour 
+        of Things using MQTT.</p>
     </section>
     <section>
-      <h2 id="modbus-binding-workitem">Modbus Protocol Binding</h2>
-      <p>The WG will work on the current Modbus Protocol Binding in order to publish it as a standalone normative
-      document. This will include a Modbus ontology, introduce default values and describe the terms associated with
-      the behavior of Things regarding the usage of the Modbus.</p>
+      <h2 id="modbus-protocol-vocabulary-workitem">Modbus Protocol Vocabulary</h2>
+      <p>The WG will work on a Modbus Protocol Vocabulary specification (based on the current Modbus Binding Template 
+        document) which provides a vocabulary for describing custom Modbus protocol bindings in Thing Descriptions.
+        This will include a Modbus ontology, introduce default values and define terms for describing the behaviour 
+        of Things using Modbus.</p>
     </section>
     <section>
-      <h2 id="bacnet-binding-workitem" class="todo">BACnet Protocol Binding</h2>
-      <p>The WG will work on specifying a BACnet Protocol Binding for the Web of Things in order to publish it as a
-      standalone normative document. This will include a BACnet ontology, introduce default values and describe the
-      terms associated with the behavior of Things regarding the usage of the BACnet. Note: How should we mention
+      <h2 id="bacnet-protocol-vocabulary-workitem" class="todo">BACnet Protocol Vocabulary</h2>
+      <p>The WG will work on a BACnet Protocol Vocabulary specification which provides a vocabulary for describing 
+        custom BACnet protocol bindings in Thing Descriptions. This will include a BACnet ontology, introduce default 
+        values and define terms for describing the behaviour of Things using BACnet. Note: How should we mention
       ASHRAE here?</p>
     </section>
     <section>
-      <h2 id="opcua-binding-workitem" class="todo">OPC UA Protocol Binding</h2>
-      <p>The WG will work on specifying an OPC UA Protocol Binding for the Web of Things in order to publish it as a
-      standalone normative document. This will include a OPC UA ontology, introduce default values and describe the
-      terms associated with the behavior of Things regarding the usage of the OPC UA. Note: How should we mention OPC
+      <h2 id="opcua-protocol-vocabulary-workitem" class="todo">OPC UA Protocol Vocabulary</h2>
+      <p>The WG will work on an OPC UA Protocol Vocabulary specification which provides a vocabulary for describing 
+        custom OPC UA protocol bindings in Thing Descriptions. This will include an OPC UA ontology, introduce default 
+        values and define terms for describing the behaviour of Things using OPC UA. Note: How should we mention OPC
       Foundation here?</p>
     </section>
     <section>
-      <h2 id="grpc-binding-workitem">gRPC Protocol Binding</h2>
-      <p>The WG will work on specifying a gRPC Protocol Binding for the Web of Things in order to publish it as a
-      standalone normative document. This will include a gRPC ontology, introduce default values and describe the terms
-      associated with the behavior of Things regarding the usage of the gRPC.</p>
+      <h2 id="grpc-protocol-vocabulary-workitem">gRPC Protocol Vocabulary</h2>
+      <p>The WG will work on a gRPC Protocol Vocabulary specification which provides a vocabulary for describing 
+        custom gRPC protocol bindings in Thing Descriptions. This will include a gRPC ontology, introduce default 
+        values and define terms for describing the behaviour of Things using gRPC.</p>
     </section>
     <section>
-      <h2 id="json-binding-workitem">JSON Payload Binding</h2>
-      <p>The WG will work on specifying a JSON Payload Binding for the Web of Things in order to publish it as a
-      standalone normative document. This will include specification on the usage of Data Schema terms as well as
+      <h2 id="json-payload-serialization-workitem">JSON Payload Serialization</h2>
+      <p>The WG will work on specifying a JSON Payload Serialization for the Web of Things in order to publish it as a
+      standalone document. This will include specification on the usage of Data Schema terms as well as
       <code>contentType</code> term usage within forms.</p>
     </section>
     <section>
-      <h2 id="cbor-binding-workitem">CBOR Payload Binding</h2>
-      <p>The WG will work on specifying a CBOR Payload Binding for the Web of Things in order to publish it as a
-      standalone normative document. This will include specification on the usage of Data Schema terms as well as
+      <h2 id="cbor-payload-serialization-workitem">CBOR Payload Serialization</h2>
+      <p>The WG will work on specifying a CBOR Payload Serialization for the Web of Things in order to publish it as a
+      standalone document. This will include specification on the usage of Data Schema terms as well as
       <code>contentType</code> term usage within forms.</p>
     </section>
     <section>
-      <h2 id="xml-binding-workitem">XML Payload Binding</h2>
-      <p>The WG will work on specifying an XML Payload Binding for the Web of Things in order to publish it as a
-      standalone normative document. This will include specification on the usage of Data Schema terms as well as
+      <h2 id="xml-payload-serialization-workitem">XML Payload Serialization</h2>
+      <p>The WG will work on specifying an XML Payload Serialization for the Web of Things in order to publish it as a
+      standalone document. This will include specification on the usage of Data Schema terms as well as
       <code>contentType</code> term usage within forms.</p>
     </section>
     <section>
-      <h2 id="cloudevents-binding-workitem">CloudEvents Payload Binding</h2>
-      <p>The WG will work on specifying an CloudEvents Payload Binding for the Web of Things in order to publish it as
-      a standalone normative document. This will include specification on the usage of Data Schema terms as well as
+      <h2 id="cloudevents-payload-serialization-workitem">CloudEvents Payload Serialization</h2>
+      <p>The WG will work on specifying an CloudEvents Payload Serialization for the Web of Things in order to publish it as
+      a standalone document. This will include specification on the usage of Data Schema terms as well as
       <code>contentType</code> term usage within forms.</p>
     </section>
     <section>
-      <h2 id="echonet-binding-workitem" class="todo">ECHONET Lite Web API Combination Binding</h2>
-      <p>The WG will work on specifying an ECHONET Lite Web API Combination Binding for the Web of Things in order to
-      publish it as a standalone normative document. This will include specification on the usage of Data Schema terms,
+      <h2 id="echonet-platform-mapping-workitem" class="todo">ECHONET Lite Web API Platform Mapping</h2>
+      <p>The WG will work on specifying an ECHONET Lite Web API Platform Mapping for the Web of Things in order to
+      publish it as a standalone document. This will include specification on the usage of Data Schema terms,
       together with how form elements should be structured with possible other assertions on the TD instances. Note:
       How should we mention ECHONET Consortium here?</p>
     </section>
@@ -556,15 +559,14 @@
       <h2 id="profiles-workitem">Interoperability Profiles</h2>
       <ol>
         <li>Complete the transition of the <a href="https://w3c.github.io/wot-profile/">WoT Profile 1.0</a> Working
-        Draft, including a first basic HTTP-based profile, to a Recommendation
+        Draft, including a first basic HTTP-based profile, to a Recommendation.
         </li>
         <li>Normatively define one or more profiles which specify how to observe properties and subscribe to events
         over HTTP, e.g. using Server-Sent Events and/or Webhooks</li>
         <li>Consider defining other profiles, e.g. a CoAP-based profile for constrained devices which do not have the
         resources to implement HTTP-based profiles</li>
-        <li>Stretch goal: Specify an updated profiling mechanism which reuses the sub-protocol and context extension
-        mechanisms from the WoT Thing Description specification, in order to more tightly constrain how profiles are
-        defined</li>
+        <li>Stretch goal: Specify an updated profiling mechanism which better integrates with the extension points of
+          other WoT specifications and more precisely defines what profiles can constrain</li>
       </ol>
     </section>
   </section>


### PR DESCRIPTION
Note: This PR only changes the details document, please add the "Detailed Work Items" label.

This is one of two proposed solutions to the conflict between the binding and profiling mechanisms identified in #14.

In this proposal the status quo is maintained in that binding documents only define a vocabulary for providing custom protocol bindings in Thing Descriptions, and profiles define common protocol bindings which can be shared between Things for out-of-the-box interoperability.

Currently the details document incorrectly uses the term "protocol binding" to refer to what is currently called a "protocol binding template". The current protocol binding template documents do not actually define protocol bindings according to the current definitions, they just define a vocabulary for describing custom protocol bindings in Thing Descriptions. This PR therefore changes the names of the binding document deliverables as follows:
- "protocol binding" -> "protocol vocabulary"
- "payload binding" -> "payload serialization"
- "combination binding" -> "platform mapping"

With this approach, there remain two separate mechanisms for defining protocol bindings in WoT:
- Prescriptive common protocol bindings in Profiles referenced in Thing Descriptions using the `profile` member, for greenfield devices
- Descriptive custom protocol bindings in Thing Descriptions using Protocol Binding Vocabularies, for brownfield devices

