### PR TITLE
Avoid use of "protocol binding" in charter

### DIFF
--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -213,8 +213,8 @@
 		<strong>Support WoT Interoperability</strong>:
 	  </dt>
           <dd>The WG will improve out-of-the-box interoperability and enable the integration of WoT into other ecosystems and communities. 
-            Thus, the WG will define core binding and profiling mechanisms, specify additional protocol and payload bindings, 
-            and define appropriate profiles.
+            Thus, the WG will define core binding and profiling mechanisms, 
+            and define additional profiles and bindings, as appropriate.
           </dd>
           <dt>
           	<strong>Improve Management of TDs</strong>:
@@ -259,7 +259,7 @@
             platforms.
             We will not define new security mechanisms but will use existing mechanisms and best practices.</dd>
           <dt><strong>Modification of protocols:</strong></dt>
-          <dd>If during work on protocol bindings, it becomes apparent that changes are needed to protocols,
+          <dd>If during work on bindings, it becomes apparent that changes are needed to protocols,
             the Web of Things Working Group will rely on the organization responsible for the protocol to make the
             changes.
             It is out of scope for the Working Group to standardize such changes itself.</dd>
@@ -528,7 +528,7 @@
         <dl>
           <dt> <a href="https://opcfoundation.org/">OPC Foundation</a>
           <dd>
-            For coordination on the development of the OPC UA Binding for the W3C Web of Things.
+            For coordination on the development of the OPC UA binding for the W3C Web of Things.
             A formal agreement between the OPC Foundation and the W3C is being considered to establish an official relationship.
           </dd>
           </dt>
@@ -539,7 +539,7 @@
           </dt>
           <dt> <a href="https://industrialdigitaltwin.org/en/">Industrial Digital Twin Association</a>
           <dd>
-            For coordination on the use of TDs and Binding Templates in the Asset Interface Description (AID) submodel
+            For coordination on the use of TDs and bindings in the Asset Interface Description (AID) submodel
             for the Asset Administration (AAS) specification.
             Additionally, the AAS submodels can be used for Digital Nameplate (DNP) and Product Carbon Footprint (PCF)
             to form the Digital Product Passport (DPP) of products
@@ -550,7 +550,7 @@
           </dt>
           <dt> <a href="https://www.ashrae.org/">ASHRAE</a>
           <dd>
-            For coordination on the development of the BACnet (ASHRAE 135-2020) Binding for the W3C Web of Things .
+            For coordination on the development of the BACnet (ASHRAE 135-2020) binding for the W3C Web of Things .
           </dd>
           </dt>
           <dt> <a href="https://www.ietf.org/">IETF</a>
@@ -566,7 +566,7 @@
         </dl>
         <dt> <a href="https://csa-iot.org/">Connectivity Standards Alliance (CSA)</a>
         <dd>
-          To coordinate smart home use cases and to develop a potential Matter Protocol Binding.
+          To coordinate smart home use cases and to develop a potential Matter binding.
         </dd>
         </dt>
         <dt> <a href="https://onedm.org/">One Data Model</a>


### PR DESCRIPTION
Prefer use of more generic "binding" term.  Also, make this generic, and not upper-case.