### PR TITLE
Update charter start and end dates

### DIFF
--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -116,7 +116,7 @@
               Start date
             </th>
             <td>
-              <i class="todo">1 June 2023 (ESTIMATED) (date of the "Call for Participation", when the charter is
+              <i class="todo">1 July 2023 (ESTIMATED) (date of the "Call for Participation", when the charter is
                 approved)</i>
             </td>
           </tr>
@@ -125,7 +125,7 @@
               End date
             </th>
             <td>
-              <i class="todo">1 June 2025 (ESTIMATED; Start date + 2 years)</i>
+              <i class="todo">1 July 2025 (ESTIMATED; Start date + 2 years)</i>
             </td>
           </tr>
           <tr>


### PR DESCRIPTION
Update start (and end) dates of charter to July.

Resolves #95 

Note: there were various publication deadlines given as June that I did NOT change.  I figure having a 1-month buffer is not a bad thing.  This also does not update the detailed timeline; I will do that in a separate PR.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/pull/106.html" title="Last updated on Mar 27, 2023, 3:22 PM UTC (4ee70a0)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/106/5c60eeb...4ee70a0.html" title="Last updated on Mar 27, 2023, 3:22 PM UTC (4ee70a0)">Diff</a>