### PR TITLE
Update timeline

### DIFF
--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -297,7 +297,9 @@
                family of WoT building block specifications described below.
             </p>
             <p class="draft-status"><b>Draft state:</b>No draft</p>
-            <p class="milestone"><b>Expected completion:</b>1 June 2025</p>
+            <p class="milestone"><b>Expected CR Transition:</b>Q4 2024</p>
+	    <p class="milestone"><b>Expected PR Transition:</b>Q2 2025</p>
+	    <p class="milestone"><b>Expected REC Transition:</b>June 2025</p>
             <p><b>Adopted Draft:</b>
             This will be an update of the current <i>Web of Things (WoT) Architecture</i> specification published
             at <a href="https://www.w3.org/TR/wot-architecture11/">https://www.w3.org/TR/wot-architecture11/</a>,
@@ -309,7 +311,9 @@
               update to the existing WoT Discovery Specification.</p>
 
             <p class="draft-status"><b>Draft state:</b>No draft</p>
-            <p class="milestone"><b>Expected completion:</b>1 June 2025</p>
+            <p class="milestone"><b>Expected CR Transition:</b>Q4 2024</p>
+	    <p class="milestone"><b>Expected PR Transition:</b>Q2 2025</p>
+	    <p class="milestone"><b>Expected REC Transition:</b>June 2025</p>
             <p><b>Adopted Draft:</b>
               This will be a revision of the current <i>Web of Things (WoT) Discovery</i> specification published
               at <a href="https://www.w3.org/TR/wot-discovery/">https://www.w3.org/TR/wot-discovery/</a>,
@@ -323,7 +327,9 @@
               </p>
 
               <p class="draft-status"><b>Draft state:</b>No draft</p>
-              <p class="milestone"><b>Expected completion:</b>1 June 2025</p>
+              <p class="milestone"><b>Expected CR Transition:</b>Q4 2024</p>
+	      <p class="milestone"><b>Expected PR Transition:</b>Q2 2025</p>
+	      <p class="milestone"><b>Expected REC Transition:</b>June 2025</p>
               <p><b>Adopted Draft:</b>
               This will be a further iteration of the current <i>Web of Things (WoT) Thing Description</i> specification published
               at <a href="https://www.w3.org/TR/wot-thing-description11/">https://www.w3.org/TR/wot-thing-description11/</a>,
@@ -338,7 +344,9 @@
               basic HTTP-based profile.
             </p>
             <p class="draft-status"><b>Draft state:</b> <a href="https://www.w3.org/TR/wot-profile/">Working Draft</a></p>
-            <p class="milestone"><b>Expected completion:</b>1 November 2023</p>
+            <p class="milestone"><b>Expected CR Transition:</b>Q4 2023</p>
+	    <p class="milestone"><b>Expected PR Transition:</b>Q1 2024</p>
+	    <p class="milestone"><b>Expected REC Transition:</b>Q3 2024</p>
           </dd>
           <dt id="profiles-deliverable-next" class="spec">Profile (Update)</dt>
           <dd>
@@ -347,7 +355,9 @@
               additional normative profiles as appropriate.
             </p>
             <p class="draft-status"><b>Draft state:</b> No draft</p>
-            <p class="milestone"><b>Expected completion:</b>1 June 2025</p>
+            <p class="milestone"><b>Expected CR Transition:</b>Q4 2024</p>
+	    <p class="milestone"><b>Expected PR Transition:</b>Q2 2025</p>
+	    <p class="milestone"><b>Expected REC Transition:</b>June 2025</p>
           </dd>
         </dl>
         </section>
@@ -388,11 +398,12 @@
           <li>Q1 2024: FPWD for updated Discovery, Thing Description, and Architecture deliverables</li>
           <li>Q1 2024: PR Transition for Profile deliverable</li>
           <li>Q2 2024: FPWD for updated Profile deliverable</li>
+	  <li>Q3 2024: REC Transition for Profile deliverable</li>
           <li>Q3 2024: Updated publication of WoT Security and Privacy Guidelines as a Note</li>
           <li>Q4 2024: CR Transition for updated Discovery, Thing Description, Architecture, and Profile deliverables</li>
           <li>Q4 2024: Updated publication of Bindings as Notes</li>
           <li>Q1 2025: Updated publication of Scripting API as a Note</li>
-          <li>Q2 2025: REC Transition for Profile deliverable</li>
+
           <li>Q2 2025: PR Transition for updated Discovery, Thing Description, Architecture, and Profile deliverables</li>
           <li>June 2025: REC Transition for updated Discovery, Thing Description, Architecture, and Profile deliverables</li>
         </ul>

--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -383,18 +383,18 @@
         <ul>
           <li>July 2023: First teleconference</li>
           <li>September 2023: First face-to-face meeting (TPAC 2023, Sevilla, Spain)</li>
-          <li>November 2023: Requirements and Use Cases updated</li>
-          <li>November 2024: CR Transition for Profile deliverable</li>
-          <li>January 2024: FPWD for updated Discovery, Thing Description, and Architecture deliverables</li>
-          <li>November 2024: PR Transition for Profile deliverable</li>
-          <li>April 2024: FPWD for updated Profile deliverable</li>
-          <li>August 2024: Updated publication of WoT Security and Privacy Guidelines as a Note</li>
-          <li>November 2024: CR Transition for updated Discovery, Thing Description, Architecture, and Profile deliverables</li>
-          <li>November 2024: Updated publication of Bindings as Notes</li>
-          <li>January 2025: Updated publication of Scripting API as a Note</li>
-          <li>March 2025: REC Transition for Profile deliverable</li>
-          <li>March 2025: PR Transition for updated Discovery, Thing Description, Architecture, and Profile deliverables</li>
-          <li>June-July 2025: REC Transition for updated Discovery, Thing Description, Architecture, and Profile deliverables</li>
+          <li>Q4 2023: Requirements and Use Cases updated</li>
+          <li>Q4 2023: CR Transition for Profile deliverable</li>
+          <li>Q1 2024: FPWD for updated Discovery, Thing Description, and Architecture deliverables</li>
+          <li>Q1 2024: PR Transition for Profile deliverable</li>
+          <li>Q2 2024: FPWD for updated Profile deliverable</li>
+          <li>Q3 2024: Updated publication of WoT Security and Privacy Guidelines as a Note</li>
+          <li>Q4 2024: CR Transition for updated Discovery, Thing Description, Architecture, and Profile deliverables</li>
+          <li>Q4 2024: Updated publication of Bindings as Notes</li>
+          <li>Q1 2025: Updated publication of Scripting API as a Note</li>
+          <li>Q2 2025: REC Transition for Profile deliverable</li>
+          <li>Q2 2025: PR Transition for updated Discovery, Thing Description, Architecture, and Profile deliverables</li>
+          <li>June 2025: REC Transition for updated Discovery, Thing Description, Architecture, and Profile deliverables</li>
         </ul>
       </section>
     </section>

--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -297,6 +297,7 @@
                family of WoT building block specifications described below.
             </p>
             <p class="draft-status"><b>Draft state:</b>No draft</p>
+	    <p class="milestone"><b>Expected FPWD:</b>Q1 2024</p>
             <p class="milestone"><b>Expected CR Transition:</b>Q4 2024</p>
 	    <p class="milestone"><b>Expected PR Transition:</b>Q2 2025</p>
 	    <p class="milestone"><b>Expected REC Transition:</b>June 2025</p>
@@ -311,6 +312,7 @@
               update to the existing WoT Discovery Specification.</p>
 
             <p class="draft-status"><b>Draft state:</b>No draft</p>
+	    <p class="milestone"><b>Expected FPWD:</b>Q1 2024</p>
             <p class="milestone"><b>Expected CR Transition:</b>Q4 2024</p>
 	    <p class="milestone"><b>Expected PR Transition:</b>Q2 2025</p>
 	    <p class="milestone"><b>Expected REC Transition:</b>June 2025</p>
@@ -327,6 +329,7 @@
               </p>
 
               <p class="draft-status"><b>Draft state:</b>No draft</p>
+	      <p class="milestone"><b>Expected FPWD:</b>Q1 2024</p>
               <p class="milestone"><b>Expected CR Transition:</b>Q4 2024</p>
 	      <p class="milestone"><b>Expected PR Transition:</b>Q2 2025</p>
 	      <p class="milestone"><b>Expected REC Transition:</b>June 2025</p>
@@ -355,6 +358,7 @@
               additional normative profiles as appropriate.
             </p>
             <p class="draft-status"><b>Draft state:</b> No draft</p>
+	    <p class="milestone"><b>Expected FPWD:</b>Q2 2024</p>
             <p class="milestone"><b>Expected CR Transition:</b>Q4 2024</p>
 	    <p class="milestone"><b>Expected PR Transition:</b>Q2 2025</p>
 	    <p class="milestone"><b>Expected REC Transition:</b>June 2025</p>

--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -381,14 +381,20 @@
       <section id="timeline">
         <h3>Timeline</h3>
         <ul>
-          <li>June 2023: First teleconference</li>
-          <li>July 2023: First face-to-face meeting</li>
-          <li>September 2023: Requirements and Use Cases for WoT Discovery 1.1</li>
-          <li>January 2024: FPWD for WoT Discovery 1.1</li>
-          <li>August 2024: CR Transition for WoT Discovery 1.1</li>
+          <li>July 2023: First teleconference</li>
+          <li>September 2023: First face-to-face meeting (TPAC 2023, Sevilla, Spain)</li>
+          <li>November 2023: Requirements and Use Cases updated</li>
+          <li>November 2024: CR Transition for Profile deliverable</li>
+          <li>January 2024: FPWD for updated Discovery, Thing Description, and Architecture deliverables</li>
+          <li>November 2024: PR Transition for Profile deliverable</li>
+          <li>April 2024: FPWD for updated Profile deliverable</li>
           <li>August 2024: Updated publication of WoT Security and Privacy Guidelines as a Note</li>
-          <li>December 2024: PR Transition for WoT Discovery 1.1</li>
-          <li>March 2025: REC Transition for WoT Discovery 1.1</li>
+          <li>November 2024: CR Transition for updated Discovery, Thing Description, Architecture, and Profile deliverables</li>
+          <li>November 2024: Updated publication of Bindings as Notes</li>
+          <li>January 2025: Updated publication of Scripting API as a Note</li>
+          <li>March 2025: REC Transition for Profile deliverable</li>
+          <li>March 2025: PR Transition for updated Discovery, Thing Description, Architecture, and Profile deliverables</li>
+          <li>June-July 2025: REC Transition for updated Discovery, Thing Description, Architecture, and Profile deliverables</li>
         </ul>
       </section>
     </section>


### PR DESCRIPTION
Resolves #97 

First cut at timeline based on a July 1 start and end date.  Please make suggested edits as appropriate.  

One tricky bit is how to interleave the "first" Profile publication and the "updated" Profile publication.  Because the short charter duration we'll still be waiting for the REC of the first Profile doc while we're well into the CR/PR process for the updated Profile doc.  It would be good however to merge these schedules at the end of the charter and do all the "updates" together.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/pull/107.html" title="Last updated on Mar 29, 2023, 11:15 AM UTC (b0e15c7)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/107/5c60eeb...b0e15c7.html" title="Last updated on Mar 29, 2023, 11:15 AM UTC (b0e15c7)">Diff</a>