### PR TITLE
Cleanup To Do Notes and Markup

### DIFF
--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -446,15 +446,17 @@
       <p>Additional technical coordination with the following Groups will be made, per the <a
           href="https://www.w3.org/Consortium/Process/#WGCharter">W3C Process Document</a>:</p>
 
+	    <!--
       <p class="todo">In addition to the above catch-all reference to horizontal review which includes accessibility
         review, please check with chairs and staff contacts of the <a href="https://www.w3.org/WAI/APA/">Accessible
           Platform Architectures Working Group</a> to determine if an additional liaison statement with more specific
         information about concrete review issues is needed in the list below.</p>
+-->
 
       <section>
         <h3 id="w3c-coordination">WoT-related W3C Groups</h3>
         <dt><a href="https://www.w3.org/groups/ig/wot">Web of Things Interest Group</a></dt>
-        <dd><span class="todo">This Working Group Charter covers those aspects that the
+        <dd>This Working Group Charter covers those aspects that the
             <a href="http://www.w3.org/groups/ig/wot">Web of Things Interest Group</a>
             <a href="https://www.w3.org/2021/12/wot-ig-2021.html">(charter here)</a>
             believes are mature enough to progress to W3C Recommendations.
@@ -462,7 +464,6 @@
               this working group is tasked with the standardization or extension of the building blocks
               identified by the use cases resulting from the work of <a href="https://www.w3.org/groups/ig/wot">the Web of
                 Things Interest Group</a> (IG) as being important to advance the Web of Things.
-          </span>
             </dd>
         <dt><a href="https://www.w3.org/community/wot/">Web of Things Community Group</a></dt>
         <dd>For collaboration on community outreach of the WG reports to increase adoption and implementation, as well as 


### PR DESCRIPTION
Cleanup to remove some "to do" items and markup
- Remove todo note about Accessibility (this was resolved)
- Remove todo highlighting from IG collaboration description.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/pull/111.html" title="Last updated on Mar 29, 2023, 11:41 AM UTC (39d50e4)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/111/5c60eeb...39d50e4.html" title="Last updated on Mar 29, 2023, 11:41 AM UTC (39d50e4)">Diff</a>