### PR TITLE
Remove links to template

### DIFF
--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -56,18 +56,18 @@
   <header id="header">
     <aside>
       <ul id="navbar">
-        <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#background">Background</a></li>
-        <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#scope">Scope</a></li>
-        <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#deliverables">Deliverables</a></li>
-        <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#success-criteria">Success Criteria</a>
+        <li><a href="#background">Background</a></li>
+        <li><a href="#scope">Scope</a></li>
+        <li><a href="#deliverables">Deliverables</a></li>
+        <li><a href="#success-criteria">Success Criteria</a>
         </li>
-        <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#coordination">Coordination</a></li>
-        <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#participation">Participation</a></li>
-        <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#communication">Communication</a></li>
-        <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#decisions">Decision Policy</a></li>
-        <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#patentpolicy">Patent Policy</a></li>
-        <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#licensing">Licensing</a></li>
-        <li><a href="https://w3c.github.io/charter-drafts/charter-template.html#about">About this Charter</a></li>
+        <li><a href="#coordination">Coordination</a></li>
+        <li><a href="#participation">Participation</a></li>
+        <li><a href="#communication">Communication</a></li>
+        <li><a href="#decisions">Decision Policy</a></li>
+        <li><a href="#patentpolicy">Patent Policy</a></li>
+        <li><a href="#licensing">Licensing</a></li>
+        <li><a href="#about">About this Charter</a></li>
       </ul>
     </aside>
     <p>
@@ -107,7 +107,7 @@
             </th>
             <td>
               See the <a href="https://www.w3.org/groups/wg/wot/charters">group status page</a>
-              and <a href="https://w3c.github.io/charter-drafts/charter-template.html#history">detailed change
+              and <a href="#history">detailed change
                 history</a>.
             </td>
           </tr>
@@ -166,7 +166,7 @@
           Document</a> requires “The level of confidentiality of the group's proceedings and deliverables”; however, it
         does not mandate where this appears. Since all W3C Working Groups should be chartered as public, this notice has
         been moved from the essentials table to the <a
-          href="https://w3c.github.io/charter-drafts/charter-template.html#public">communication section</a>.</p>
+          href="#public">communication section</a>.</p>
 -->
     </div>
 
@@ -506,10 +506,6 @@
         </dd>
         <h3 id="w3c-coordination">Other W3C Groups</h3>
         <dl>
-          <!--
-            <dt><a href="https://w3c.github.io/charter-drafts/charter-template.html"><i class="todo">[other name]</i> Working Group</a></dt>
-              <dd><i class="todo">[specific nature of liaison]</i></dd>
-          -->
  	    <dt><a href="https://www.w3.org/2018/json-ld-wg/">JSON-LD Working Group</a></dt>
 	      <dd>For collaboration on JSON-LD features and WoT use cases.</dd>
 	    <dt><a href="https://www.w3.org/community/exi-next/">Efficient Extensible Interchange Community Group</a></dt>
@@ -646,7 +642,7 @@
       <p>
         The group encourages questions, comments and issues on its public mailing lists and document repositories, as
         described in <a
-          href="https://w3c.github.io/charter-drafts/charter-template.html#communication">Communication</a>.
+          href="#communication">Communication</a>.
       </p>
       <p>
         The group also welcomes non-Members to contribute technical submissions for consideration upon their agreement


### PR DESCRIPTION
There were a bunch of links to internal sections that actually pointed to the template.  Fixed to be relative links.  Also removed a commented-out section that was not useful.

There is still one link to the template in the history table that we should update eventually when the charter is finalized.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/pull/116.html" title="Last updated on Apr 26, 2023, 10:12 AM UTC (afa6102)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/116/90a0a62...afa6102.html" title="Last updated on Apr 26, 2023, 10:12 AM UTC (afa6102)">Diff</a>