### PR TITLE
Estimated Start Date Updated, Details Link removed

### DIFF
--- a/wot-wg-2023-draft.html
+++ b/wot-wg-2023-draft.html
@@ -116,7 +116,7 @@
               Start date
             </th>
             <td>
-              <i class="todo">1 July 2023 (ESTIMATED) (date of the "Call for Participation", when the charter is
+              <i class="todo">1 September 2023 (ESTIMATED) (date of the "Call for Participation", when the charter is
                 approved)</i>
             </td>
           </tr>
@@ -125,7 +125,7 @@
               End date
             </th>
             <td>
-              <i class="todo">1 July 2025 (ESTIMATED; Start date + 2 years)</i>
+              <i class="todo">1 September 2025 (ESTIMATED; Start date + 2 years)</i>
             </td>
           </tr>
           <tr>
@@ -249,11 +249,6 @@
             and other work as appropriate.
           </dd>
         </dl>
-
-      <p>
-        Details for planned work items, which however are subject to change, are available in a 
-        <a href="https://w3c.github.io/wot-charter-drafts/wot-wg-2023-details.html">separate document</a>.
-      </p>
 
       </div>
 
@@ -405,7 +400,7 @@
       <section id="timeline">
         <h3>Timeline</h3>
         <ul>
-          <li>July 2023: First teleconference</li>
+          <li>September 2023: First teleconference</li>
           <li>September 2023: First face-to-face meeting (TPAC 2023, Sevilla, Spain)</li>
           <li>Q4 2023: Requirements and Use Cases updated</li>
           <li>Q4 2023: CR Transition for Profile deliverable</li>


### PR DESCRIPTION
Changes to draft charter:
- Updated estimated start date to 1 September (based on current progress through review process)
- Updated calendar to say first teleconference would be in September (no specific date, probably right before TPAC)
- Removed link to "details" document for work items
- Did NOT update dates for deliverables, etc.
- Did NOT update end date for current charter (we still need to confirm an extension)


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/pull/117.html" title="Last updated on Jul 5, 2023, 11:56 AM UTC (239be32)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/wot-charter-drafts/117/af3d5b5...239be32.html" title="Last updated on Jul 5, 2023, 11:56 AM UTC (239be32)">Diff</a>