### PR TITLE
IG 2023 charter initial draft

### DIFF
--- a/wot-ig-2023-draft.html
+++ b/wot-ig-2023-draft.html
@@ -1,0 +1,891 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <meta charset="utf-8">
+
+    <title>Web of Things Interest Group Charter (DRAFT)</title>
+
+    <link rel="stylesheet" href="https://www.w3.org/2005/10/w3cdoc.css" type="text/css" media="screen">
+    <link rel="stylesheet" type="text/css" href="https://www.w3.org/OldGuide/pubrules-style.css">
+    <link rel="stylesheet" type="text/css" href="https://www.w3.org/2006/02/charter-style.css">
+    <style>
+      main {
+        max-width: 60em;
+        margin: 0 auto;
+      }
+
+      ul#navbar {
+        font-size: small;
+      }
+
+      dt.spec {
+        font-weight: bold;
+      }
+
+      dt.spec new {
+        background: yellow;
+      }
+
+      ul.out-of-scope > li {
+        font-weight: bold;
+      }
+
+      ul.out-of-scope > li > ul > li{
+        font-weight: normal;
+      }
+
+      .issue {
+        background: cornsilk;
+        font-style: italic;
+      }
+
+      .todo {
+        color: #900;
+      }
+
+      footer {
+        font-size: small;
+      }
+
+<!-- additional style -->
+<!-- Include the following though originally not in the official template -->
+      span.caption {
+        display: block;
+        text-align: center;
+        font-style: italic;
+      }
+      section {
+        clear: both;
+      }
+      div.summary {
+        clear: both;
+        margin-top: 0.5em;
+        margin-left: 20%;
+        margin-right: 20%;
+        padding: 0.5em;
+        background: rgb(240,240,255);
+        border: solid 1px black;
+      }
+      #relationships {
+        float:right;
+        margin-left: 0.6em;
+        width:40%;
+        min-width:250px;
+        max-width:936px;
+      }
+      #deliverables dt {
+        font-weight: bold;
+        margin-top: 0.5em;
+      }
+      .info {
+        background-color: #ddd;
+        margin-top: 1em;
+        padding: 15px;
+        border: 1px solid transparent;
+        border-radius: 4px;
+      }
+    </style>
+  </head>
+  <body>
+    <header id="header">
+      <aside>
+        <ul id="navbar">
+          <li><a href="#background">Background</a></li>
+          <li><a href="#scope">Scope</a></li>
+          <li><a href="#deliverables">Deliverables</a></li>
+<!-- Not needed for IG?
+		  <li><a href="#success-criteria">Success Criteria</a></li>
+-->
+          <li><a href="#coordination">Coordination</a></li>
+          <li><a href="#participation">Participation</a></li>
+          <li><a href="#communication">Communication</a></li>
+          <li><a href="#decisions">Decision Policy</a></li>
+          <li><a href="#patentpolicy">Patent Disclosures</a></li>
+          <li><a href="#licensing">Licensing</a></li>
+          <li><a href="#about">About this Charter</a></li>
+        </ul>
+      </aside>
+      <p>
+        <a href="https://www.w3.org/"><img alt="W3C" height="48" src="https://www.w3.org/Icons/w3c_home" width="72"></a>
+      </p>
+    </header>
+
+
+    <main>
+      <h1 id="title">PROPOSED Web of Things Interest Group Charter</h1>
+      <!-- delete PROPOSED after AC review completed -->
+
+<!--
+      <p class="mission">The <strong>mission</strong> of the <a href=""><i class="todo">[name]</i> (Working|Interest) Group</a> is to <i class="todo">[do something cool and specific on the Web]</i>.</p>
+-->
+      <!-- the link to the group is ALWAYS that available from https://www.w3.org/groups/wg or https://www.w3.org/groups/ig because each group page can then point to a different homepage, but not the other way around. -->
+
+      <p class="mission">
+        The <strong>mission</strong> of the <a href="https://www.w3.org/groups/ig/wot">Web of Things Interest Group</a> is to counter the fragmentation of the 
+        Internet of Things by complementing available standards through Web technology capable of
+        interconnecting existing Internet of Things platforms, devices, gateways, and cloud services.
+        We aim to reduce costs through the global reach of Web standards, to enable open markets of services, and to unleash the power of the network effect.
+        As a W3C Interest Group, we are seeking to build a deeper understanding of the Web of Things by investigating consumer, industrial, environmental, 
+        energy management, and smart city scenarios.
+        This is intended to identify demand for further standards-track work within W3C working groups and to better align with the established W3C liaisons.
+      </p>
+
+<!--
+      <div class="noprint">
+        <p class="join"><a href="https://www.w3.org/groups/wg/[shortname]/join">Join the <i class="todo">[name]</i> (Working|Interest) Group.</a></p>
+      </div>
+-->
+      <div class="noprint">
+        <p class="join"><a href="https://www.w3.org/2004/01/pp-impl/75874/join">Join the Web of Things Interest Group</a>.</p>
+      </div>
+
+         <p style="padding: 0.5ex; border: 1px solid green"> This proposed charter is available
+      on <a href="https://github.com/w3c/wot/charters/wot-ig-2023-draft.html">GitHub</a> 
+       (rendered version here
+       <a href="https://w3c.github.io/ot/charters/wot-ig-2023-draft.html">here</a>)
+    Feel free to raise <a href="https://github.com/w3c/wot/issues">issues</a></i>.
+          </p>
+
+      <div id="details">
+        <table class="summary-table">
+          <tr id="Status">
+            <th>
+              Charter Status
+            </th>
+            <td>
+              See the <a href="https://www.w3.org/groups/ig/wotcharters">group status page</A> and <a href="#history">detailed change history</a>.
+            </td>
+          </tr>		
+          <tr id="Duration">
+            <th>
+              Start date
+            </th>
+            <td>
+              <i class="todo">1 January 2024 (Estimated; date of the "Call for Participation", when the charter is approved)</i>
+            </td>
+          </tr>
+          <tr id="CharterEnd">
+            <th>
+              End date
+            </th>
+            <td>
+              <i class="todo">31 December 2025</i> (Estimated; Start date + 2 years)
+            </td>
+          </tr>
+          <tr>
+            <th>
+              Chairs
+            </th>
+            <td>
+              (PROPOSED)
+              Michael McCool (Intel Corp.) and
+              Sebastian Kaebisch (Siemens AG)
+            </td>
+          </tr>
+          <tr>
+            <th>
+              Team Contacts
+            </th>
+            <td>
+              <a href="mailto:ashimura@w3.org">Kazuyuki Ashimura</a> (0.1 <abbr title="Full-Time Equivalent">FTE</abbr>)
+            </td>
+          </tr>
+          <tr>
+            <th>
+              Meeting Schedule
+            </th>
+            <td>
+              <strong>Teleconferences:</strong> weekly with additional topic-specific calls as appropriate.<br>
+              <strong>Face-to-face:</strong> we will meet during the W3C's annual Technical Plenary week; 
+                 additional face-to-face meetings may be scheduled by consent of the participants,
+                 usually no more than 3 per year.
+            </td>
+          </tr>
+        </table>
+
+<!--
+        <p class="issue"><b>Note:</b> The <a href="https://www.w3.org/Consortium/Process/#WGCharter">W3C Process Document</a> requires “The level of confidentiality of the group's proceedings and deliverables”; however, it does not mandate where this appears. Since all W3C Working Groups should be chartered as public, this notice has been moved from the essentials table to the <a href="#public">communication section</a>.</p>
+-->
+      </div>
+
+      <div id="background" class="background">
+        <h2>Motivation and Background</h2>
+        <p>
+          The Internet of Things (IoT) suffers from a lack of interoperability across platforms.
+          As a result developers are faced with data silos, high integration and maintenance costs, and limited market potential.
+          Existing IoT standards address only limited ecosystems and do not provide interoperability across domains.
+          The current IoT is like the Internet before the World Wide Web, with competing incompatible hypertext systems.
+          The W3C is applying lessons learned from the World Wide Web to the Internet of Things to create the Web of Things.
+        </p>
+        <p>
+          To achieve this goal for cross-platform and cross-domain interoperability,
+          the <a href="https://www.w3.org/groups/wg/wot">Web of Things Working Group</a> has developed a first set of standardized building blocks.
+          The core idea is based upon rich metadata that describes the data and possible interactions (i.e., affordances) exposed to applications,
+          and the communications and security requirements for platforms to communicate effectively.
+          The central documents are the <a href="https://www.w3.org/TR/wot-architecture/">WoT Architecture</a> and 
+          <a href="https://www.w3.org/TR/wot-thing-description/">WoT Thing Description</a> with its <i>Properties, Actions, Events</i> interaction model.
+        </p>
+        <p>
+          The <a href="https://www.w3.org/groups/ig/wot">Web of Things Interest Group</a> continues its work to support the WoT Working Group 
+          and to explore opportunities for new standards-track work within W3C.
+          The priority in this third charter period is gaining additional practical experience with the in-development building blocks in the field
+          to enable open markets of services on the scale of the Web.
+          To achieve this goal, the Interest Group is seeking to broaden the range of participants to provide the necessary skills
+          and resources for real-world application scenarios in different verticals.
+        </p>
+      </div>
+
+      <section id="scope" class="scope">
+        <h2>Scope</h2>
+<!--
+        <p><i class="todo">What exactly is in scope, and out of scope.
+          For legal review. Be brief.</i></p>
+-->
+        <div class="summary">
+            <p style="text-align:center;font-weight:bold;">Scope Summary</p>
+            <ul>
+                <li>Support the Web of Things Working Group</li>
+                <li>Organize and run interoperability and testing events,
+                    including events for specific vertical industries, to evaluate
+                    the current working assumptions in regard to the Web of Things</li>
+                <li>Reach out and collaborate with interested organizations, 
+                    industry specific and infrastructure vendors, 
+                    and communities in support of the Interest Group's mission</li>
+                <li>Develop supporting materials such as implementation guidelines and tutorials</li>
+                <li>Explore areas and identify work that is ready for transfer to the W3C Recommendation Track</li>
+            </ul>
+        </div>
+
+        <p>
+          <a href="./wot-ig-2023_files/wot-ig-2019-relationship.png"><img id="relationships" src="./wot-ig-2023_files/wot-ig-relationship.png" alt="relationship between WoT IG and WG"></a>
+          The Web of Things Interest Group (WoT IG) is a forum for discussion of ideas relating to the Web of Things
+          and is intended to complement the role of the Web of Things Working Group (WoT WG).
+          In particular, the WoT IG will propose new work items based upon new requirements, use cases,
+          and discussions with IoT developer communities, 
+          standards development organizations,
+          industry alliances,
+          and vertical industry solution and infrastructure providers.
+          Conversely, the WoT IG will consider new topics that are submitted to it by the WoT WG.
+        </p>
+
+        <h3 id="plugfest">PlugFest and Testing</h3>
+        <p>
+          An important activity is the operation of PlugFests to collect interoperability implementation experience 
+          and to validate the current working assumptions of the potential building blocks discussed in the Web of Things Interest Group.
+          These events enable developers to get together to test their implementations and facilitates networking between partners and experts.
+          The Interest Group will seek to encourage work on open source projects and community evaluation of the Web of Things.
+          In more detail, PlugFests allow participants to:
+        </p>
+        <ul>
+          <li>assist with preparing implementation reports for WoT WG Candidate Recommendations</li>
+          <li>test-drive upcoming or proposed technologies for the W3C Recommendation Track</li>
+          <li>identify and test-drive upcoming or proposed technologies as they apply to the collection of technologies required to address specific industry and user community needs</li>
+          <li>take part in interoperability experiments across implementations for ideas at different levels of maturity</li>
+          <li>reach out to other communities and new members through an OpenDay for non-members, which usually includes a demo track</li>
+          <li>ensure interoperability between WoT technologies and assistive technologies used by people with disabilities</li>
+        </ul>
+
+        <h3 id="usecases">Use Cases and Requirements</h3>
+        <p>
+          The Interest Group will identify requirements for standardization in two ways: first, by exploring use cases and requirements for concrete consumer, industrial, 
+          environmental, energy management, and smart cities application scenarios, and second, through examining the requirements for integrating a broad range of IoT platforms into the Web of Things.
+          The exploration tasks that the Interest Group will undertake may include:
+        </p>
+        <ul>
+          <li>use cases and requirements for different application scenarios and user communities</li>
+          <li>lifecycle management of Things</li>
+          <li>security requirements and supporting technologies, such as key management and access controls</li>
+          <li>clarify relationship with the concept of Digital Twins</li>
+          <li>out-of-the-box device onboarding to cloud services</li>
+          <li>WoT Scripting API and possible simplifications</li>
+          <li>hypermedia-driven interactions for complex/multi-step Actions and Events</li>
+          <li>community-driven, bottom-up vocabulary to enable semantic interoperability</li>
+          <li>Concrete protocol bindings (e.g. for HTTP, WebSockets, CoAP)</li>
+        </ul>
+
+        <p>
+          Further ideas for topics are expected from discussions and expert presentations of IoT projects,
+          including for example,
+          Graph Data,
+          Edge Computing,
+          Machine Learning,
+          and Sustainability.
+          The Interest Group will incubate work items for the Web of Things until they are ready for transfer to the W3C Recommendation Track, 
+          either in existing Working Groups, such as the WoT WG, or in new Working Groups.
+        </p>
+
+        <p>During the <a href="https://www.w3.org/2019/07/wot-ig-2019.html">previous Charter period</a>,
+            the group developed the Use Cases and Requirements document (<a href="https://www.w3.org/TR/wot-usecases/">published Note</a>,
+            <a href="https://w3c.github.io/wot-usecases/">latest Editor's draft on GitHub</a>),
+            which represents the needs of related SDOs like Conexxus, ITU-T SG20, OGC, ECHONET, ECLASS and OPC-UA as well as 
+            the W3C Member companies.</p>
+
+<!--
+        <p>During the <a href="https://www.w3.org/2019/07/wot-ig-2019.html">previous Charter period</a>,
+            the group developed the Use Cases and Requirements document (<a href="https://www.w3.org/TR/wot-usecases/">published Note</a>,
+            <a href="https://w3c.github.io/wot-usecases/">latest Editor's draft on GitHub</a>),
+            which represents the needs of related SDOs like Conexxus, ITU-T SG20, OGC, ECHONET, ECLASS and OPC-UA as well as 
+            the W3C Member companies.</p>
+-->
+
+       <p>
+          Users may be either working wholly in a non-Latin script, or
+          in an environment where different actors are using different
+          languages. Any requirements and use cases arising from
+          investigation of international use should, of course, then be
+          reflected in the experience and/or implementation reports for
+          identified building blocks and any primer, best practice, or
+          test case documents.
+        </p>
+
+        <h3 id="marketing">Marketing and Outreach</h3>
+        <p>To reach out and collaborate with the community as mentioned
+        in the scope, the Marketing Task Force works on promoting the
+        W3C Web of Things in different ways such as Web presence, Social
+        Media presence, and more. 
+<!-- In the last charter period, we have
+        worked on establishing our website, created an explainer video
+        for the WoT, increased our social media presence, and worked on
+        documenting our work in a more approachable way.
+-->
+</p>
+
+<!--
+        <p>During the <a href="https://www.w3.org/2019/07/wot-ig-2019.html">previous Charter period</a> we got the following for the Marketing TF:</p>
+        <ul>
+            <li>Newly created <a href="https://www.w3.org/WoT/">WoT Welcome Web site</a> on the WoT-related activity in general including the WoT IG, WG and CG</li>
+            <li><a href="https://www.w3.org/WoT/videos/">Video resources</a> on WoT Introduction and Tutorials</li>
+            <li><a href="https://www.w3.org/WoT/documentation/">Supplementary documetation on WoT for Web engineers</a></li>
+            <li><a href="https://www.w3.org/WoT/developers/">Documentation on WoT implementations and related tools</a> to help developers</li>
+        </ul>
+-->
+
+
+        <section id="section-out-of-scope">
+          <h3 id="out-of-scope">Out of Scope</h3>
+            <p>The following features are out of scope, and will not be addressed by this <i class="todo">(Working|Interest)</i> group.</p>
+
+            <ul class="out-of-scope">
+            </ul>
+          <p>
+            The technical development of standards is not in scope for the Interest Group.
+            Identified Recommendation Track opportunities will be handed over to appropriate W3C groups if such a group exists, 
+		  or within a dedicated Community Group or Business Group when incubation is needed.
+          </p>
+        </section>
+
+      </section>
+
+      <section id="deliverables">
+        <h2>
+          Deliverables
+        </h2>
+        <p>
+          The primary deliverables of the WoT Interest Group are IG Notes that identify use cases and requirements 
+		for existing and/or new WoT building blocks (i.e., technical specifications by the WoT Working Group).
+          The IG Notes may contain the consensus of first implementation experiences gained by the group (e.g., during PlugFests).
+          The group will also maintain a public list of identified WoT building blocks that it is tracking and investigating.
+        </p>
+
+        <section id="normative">
+          <h3>Normative Specifications</h3>
+          <p>
+            The Interest Group will not deliver any normative specifications.
+          </p>
+        </section>
+
+        <section id="ig-other-deliverables">
+          <h3>Other Deliverables</h3>
+          <p>
+            Other non-normative documents may be created such as:
+          </p>
+          <ul>
+            <li>use case and requirement documents;</li>
+            <li>experience and/or implementation reports for identified building blocks;</li>
+            <li>primers/tutorials, best practice, implementation guidelines, or test case documents (including security) 
+		    to support WoT developers when designing applications and/or Things.</li>
+          </ul>
+
+        </section>
+
+        <section id="timeline">
+          <h3>Timeline</h3>
+            <p class="todo">Put here a timeline view of all deliverables.</p>
+            <ul class="todo">
+              <li>Month YYYY: First teleconference</li>
+              <li>Month YYYY: First face-to-face meeting</li>
+              <li>Month YYYY: Requirements and Use Cases for FooML</li>
+              <li>Month YYYY: FPWD for FooML</li>
+              <li>Month YYYY: Requirements and Use Cases for BarML</li>
+              <li>Month YYYY: FPWD FooML Primer</li>
+            </ul>
+        </section>
+      </section>
+
+<!-- In template, needed for IG? Everything here is about (normative) "specs", so... -->
+<!--
+	<section id="success-criteria">
+	  <h2>Success Criteria</h2>
+	  <p><span class='todo'>Remove this clause if the Group does not intend to move to REC:</span> In order to advance to 
+		  <a href="https://www.w3.org/Consortium/Process/#RecsPR" title="Proposed Recommendation">Proposed Recommendation</a>, each normative specification is expected to have 
+		  <a href="https://www.w3.org/Consortium/Process/#implementation-experience">at least two independent interoperable
+			  implementations</a> of every feature defined in the specification, where
+interoperability can be verified by passing open test suites, and two or
+more implementations interoperating with each other. In order to advance to
+Proposed Recommendation, each normative specification must have an open
+test suite of every feature defined in the specification.</p>
+	  <p>There should be testing plans for each specification, starting from the earliest drafts.</p>
+    <p><span class='todo'>Consider adopting a healthy testing policy, such as:</span> 
+      To promote interoperability, all changes made to specifications 
+      in Candidate Recommendation 
+      or to features that have deployed implementations
+      should have <a href='https://www.w3.org/2019/02/testing-policy.html'>tests</a>.  
+      Testing efforts should be conducted via the <a href="https://github.com/web-platform-tests/wpt">Web Platform Tests</a> project.</p>
+
+    <p>Each specification should contain sections detailing all known security and
+      privacy implications for implementers, Web authors, and end users.</p>
+
+	  <p><i class="todo">For specifications of technologies that directly impact user experience, such as content technologies, as well as protocols and APIs which impact content: </i>
+		Each specification should contain a section on accessibility that describes the benefits and impacts, including ways specification features can be used to address them, and
+		recommendations for maximising accessibility in implementations.</p>
+
+    <p>This <i class="todo">(Working|Interest)</i> Group expects to follow the
+    TAG <a href="https://www.w3.org/TR/design-principles/">Web Platform Design Principles</a>.
+    </p>
+	
+	  <p><span class='todo'>Consider adding this clause if the Group does not intend to move to REC:</span> All new features should be supported by at least two intents to implement before being incorporated in the specification.</p>
+	</section>
+-->
+
+      <section id="coordination">
+        <h2>Coordination</h2>
+        <p>For all deliverables, 
+           this Interest Group will seek <a href="https://www.w3.org/Guide/Charter.html#horizontal-review">horizontal review</a> 
+           for accessibility, internationalization, performance, privacy, and security with the relevant Working and Interest Groups, 
+           and with the <a href="https://www.w3.org/2001/tag/" title="Technical Architecture Group">TAG</a>. 
+           Invitation for review must be issued during each major standards-track document transition, 
+           including <a href="https://www.w3.org/Consortium/Process/#RecsWD" title="First Public Working Draft">FPWD</a> .
+           The Interest Group is encouraged to engage collaboratively with the horizontal review groups throughout development of
+            each document.  The Interest Group is also encouraged
+           to proactively notify the horizontal review groups when major changes occur in its technical reports following a review.
+        </p>
+
+        <p>Additional technical coordination with the following Groups will be made, 
+          per the <a href="https://www.w3.org/Consortium/Process/#WGCharter">W3C Process Document</a>:</p>
+
+        <section>
+          <h3 id="w3c-coordination">W3C Groups</h3>
+          <dl>
+            <dt><a href="https://www.w3.org/groups/wg/wot">Web of Things Working Group</a></dt>
+            <dd>For collaboration as outlined under <a href="https://www.w3.org/2021/12/wot-ig-2021.html#scope">Scope</a>.</dd>
+            <dt><a href="https://www.w3.org/2018/json-ld-wg/">JSON-LD Working Group</a></dt>
+            <dd>For collaboration on JSON-LD features and WoT use cases.</dd>
+            <dt><a href="https://www.w3.org/community/exi-next/">Efficient Extensible Interchange Community Group</a></dt>
+            <dd>In relation to efficient interchange for Thing Descriptions.</dd>
+            <dt><a href="https://www.w3.org/auto/">Web and Automotive Business &amp; Working Groups</a></dt>
+            <dd>For collaboration on technologies and requirements relating to connected cars and the Web of Things.</dd>
+            <dt><a href="https://www.w3.org/das/">Device and Sensors Working Group</a></dt>
+            <dd>For coordination on APIs for sensors and actuators.</dd>
+            <dt><a href="https://www.w3.org/WAI/APA/">Accessible Platform Architectures Working Group</a></dt>
+            <dd>For coordination on development of use cases and requirements, and impact of Web of Things technologies on accessibility for users with disabilities.</dd>
+            <dt><a href="https://www.w3.org/Privacy/">Privacy Interest Group</a></dt>
+            <dd>For collaboration on privacy considerations for the Web of Things.</dd>
+            <dt><a href="https://www.w3.org/International/">Internationalization Interest Group</a></dt>
+            <dd>For collaboration on internationalization considerations for the Web of Things.</dd>
+            <dt><a href="https://www.w3.org/web-networks/">Web &amp; Networks Interest Group</a></dt>
+            <dd>For collaboration on networking technologies on the edge and in the cloud when exposing interactions between Things.</dd>
+          </dl>
+
+<!--
+          <p class="issue"><b>Note:</b> Do not list horizontal groups here, only specific WGs relevant to your work.</p>
+          <p class="issue"><b>Note:</b> Do not bury normative text inside the liaison section.
+            Instead, put it in the scope section.</p>
+-->
+        </section>
+
+        <section>
+          <h3 id="external-coordination">External Organizations</h3>
+<!--
+          <dl>
+            <dt><a href=""><i class="todo">[other name]</i> Working Group</a></dt>
+            <dd><i class="todo">[specific nature of liaison]</i></dd>
+          </dl>
+-->
+
+          <p>
+            To succeed in establishing inter-platform standards,
+            W3C needs to coordinate with IoT alliances and standards development organizations.
+            The following list provides examples of organizations with which the Interest Group has already had significant coordination during the period of the first charter. A <a href="https://www.w3.org/WoT/IG/wiki/How_does_W3C_compare_to_other_organizations">longer list</a> is available on the Interest Group wiki.
+          </p>
+          <dl>
+            <dt><a href="https://datatracker.ietf.org/doc/charter-irtf-t2trg/">IRTF Thing to Thing Research Group</a></dt>
+            <dd>For coordination of matters of mutual interest in relation to the Web of Things.</dd>
+            <dt><a href="http://openconnectivity.org/">Open Connectivity Foundation</a></dt>
+            <dd>For collaboration on integrating OCF based platforms within the Web of Things, including platform metadata and approaches for enabling semantic interoperability, and end to end security across platforms.</dd>
+            <dt><a href="https://echonet.jp/english/">ECHONET Consortium</a></dt>
+            <dd>For collaboration on integrating ECHONET Consortium based platforms within the Web of Things, including platform metadata and approaches for enabling semantic interoperability, and end to end security across platforms.</dd>
+            <dt><a href="http://www.iiconsortium.org/">Industrial Internet Consortium</a></dt>
+            <dd>For collaboration on a testbed and gathering user requirements for the Web of Things.</dd>
+            <dt><a href="https://opcfoundation.org/">OPC Foundation</a></dt>
+            <dd>For collaboration on semantic interoperability in terms of information model, protocol binding, and security.</dd>
+            <dt><a href="https://www.plattform-i40.de/I40/Navigation/EN/Home/home.html">Plattform Industrie 4.0</a></dt>
+            <dd>For collaboration on use cases and requirements for smart manufacturing, including semantic interoperability, asset administration shell (digital twins), and end to end security across platforms.</dd>
+            <dt><a href="http://www.onem2m.org/">oneM2M</a></dt>
+            <dd>For collaboration on integrating M2M based platforms within the Web of Things, including platform metadata and approaches for enabling semantic interoperability, and end to end security across platforms.</dd>
+            <dt><a href="https://www.etsi.org/">ETSI</a></dt>
+            <dd>For collaboration on IoT, M2M, security, and semantic interoperability.</dd>
+            <dt><a href="https://www.omaspecworks.org/">OMA SpecWorks</a></dt>
+            <dd>For collaboration on integrating LWM2M based platforms with the Web of Things.</dd>
+            <dt><a href="https://www.opengeospatial.org/">Open Geospatial Consortium</a></dt>
+            <dd>For coordination on the OGC SensorThings API and location metadata.</dd>
+            <dt><a href="http://www.gsma.com/">GSMA</a></dt>
+            <dd>For coordination in respect to the interests of Network Operators.</dd>
+            <dt><a href="https://www.eclass.eu/en.html">ECLASS</a></dt>
+            <dd>For collaboration and coordination of the technical realization of the use of ECLASS in the W3C Thing Description.</dd>
+            <dt><a href="https://aioti.eu/">AIOTI WG03</a></dt>
+            <dd>For coordination with the Alliance for Internet of Things Innovation, Working Group 3 (standardisation), in respect to use cases, requirements, and semantic interoperability.</dd>
+            <dt><a href="https://www.itu.int/">ITU-T SG20</a></dt>
+            <dd>For developing a unified definition of Web of Things concepts and architecture.</dd>
+          </dl>
+        </section>
+      </section>
+
+
+
+      <section class="participation">
+        <h2 id="participation">
+          Participation
+        </h2>
+        <p>
+          To be successful, 
+          this Interest Group is expected to have 6 or more active participants for its duration, 
+          including representatives from the key implementors of this specification, 
+          and active Editors and Test Leads for each specification. 
+          The Chairs, specification Editors, 
+          and Test Leads are expected to contribute half of a working day 
+          per week towards the Interest Group. 
+          There is no minimum requirement for other Participants.
+        </p>
+        <p>
+          The group encourages questions, comments and issues on its public mailing lists and document repositories, as described in <a href='#communication'>Communication</a>.
+        </p>
+        <p>
+          The group also welcomes non-Members to contribute technical submissions for consideration upon their agreement to the terms of the <a href="https://www.w3.org/Consortium/Patent-Policy/">W3C Patent Policy</a>.
+        </p>
+        <p>Participants in the group are required (by the <a href="https://www.w3.org/Consortium/Process/#ParticipationCriteria">W3C Process</a>) to follow the
+          W3C <a href="https://www.w3.org/Consortium/cepc/">Code of Ethics and Professional Conduct</a>.</p>
+      </section>
+
+
+
+      <section id="communication">
+        <h2>
+          Communication
+        </h2>
+        <p id="public">
+          Technical discussions for this Interest Group are conducted in 
+          <a href="https://www.w3.org/Consortium/Process/#confidentiality-levels">public</a>: 
+          the meeting minutes from teleconference and face-to-face meetings will be archived for public review,
+          and technical discussions and issue tracking will be conducted in a manner that
+          can be both read and written to by the general public.
+          Working Drafts and Editor's Drafts of specifications will be developed in public repositories 
+          and may permit direct public contribution requests.
+          The meetings themselves are not open to public participation, however.
+        </p>
+        <p>
+          Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) 
+           will be available from the <a href="https://www.w3.org/groups/ig/wot">Web of Things Interest Group home page.</a>
+        </p>
+        <p>
+          Most Web of Things Interest Group teleconferences will focus on discussion of particular specifications, 
+          and will be conducted on an as-needed basis.
+        </p>
+        <p>
+          This group primarily conducts its technical work  
+<!--
+on the public mailing list <a class="todo" id="public-name" href="mailto:public-[email-list]@w3.org">public-<i class="todo">[email-list]</i>@w3.org</a> (<a class="todo" href="https://lists.w3.org/Archives/Public/public-[email-list]/">archive</a>)
+          <i class="todo">or</i> on <a class="todo" id="public-github" href="[link to Github repo]">GitHub issues</a>.
+          The public is invited to review, discuss and contribute to this work.
+-->
+                on <a id="public-github" href="https://github.com/w3c/wot">GitHub issues</a>.
+                The public is invited to review, discuss and contribute to this work.</p> 
+        <p>
+          The group may use a Member-confidential mailing list for administrative purposes and, at the discretion of the Chairs and members of the group, for member-only discussions in special cases when a participant requests such a discussion.
+        </p>
+      </section>
+
+      <section id="decisions">
+        <h2>
+          Decision Policy
+        </h2>
+        <p>
+          This group will seek to make decisions through consensus and due process, 
+          per the <a href="https://www.w3.org/Consortium/Process/#Consensus">W3C Process Document (section 5.2.1, Consensus)</a>. 
+          Typically, an editor or other participant makes an initial proposal, 
+          which is then refined in discussion with members of the group and other reviewers, 
+          and consensus emerges with little formal voting being required.</p>
+        <p>
+          However, 
+          if a decision is necessary for timely progress and consensus is not achieved after careful consideration 
+          of the range of views presented, 
+          the Chairs may call for a group vote and record a decision along with any objections.
+        </p>
+        <p>
+          To afford asynchronous decisions and organizational deliberation, 
+		any resolution (including publication decisions) taken in a face-to-face meeting or teleconference will be considered provisional.
+          A call for consensus (CfC) will be issued for all resolutions (for example, via email and/or web-based survey), with a response period from one week to 10 working days, depending on the chair's evaluation of the group consensus on the issue.
+          If no objections are raised on the mailing list by the end of the response period, the resolution will be considered to have consensus as a resolution of the Interest Group.
+        </p>
+        <p>
+          All decisions made by the group should be considered resolved unless and until new information becomes available or unless reopened at the discretion of the Chairs or the Director.
+        </p>
+        <p>
+          This charter is written in accordance with the <a href="https://www.w3.org/Consortium/Process/#Votes">W3C Process Document (Section 5.2.3, Deciding by Vote)</a> and includes no voting procedures beyond what the Process Document requires.
+        </p>
+      </section>
+
+
+
+      <section id="patentpolicy">
+
+        <h2>Patent Disclosures </h2>
+        <p>The Interest Group provides an opportunity to
+          share perspectives on the topic addressed by this charter. W3C reminds
+          Interest Group participants of their obligation to comply with patent
+          disclosure obligations as set out in <a href="https://www.w3.org/Consortium/Patent-Policy/#sec-Disclosure">Section
+            6</a> of the W3C Patent Policy. While the Interest Group does not
+          produce Recommendation-track documents, when Interest Group
+          participants review Recommendation-track specifications from Working
+          Groups, the patent disclosure obligations do apply. For more information about disclosure obligations for this group,
+          please see the <a href="https://www.w3.org/groups/ig/wot/ipr">licensing information</a>.</p>
+      </section>
+
+
+      <section id="licensing">
+        <h2>Licensing</h2>
+        <p>This Interest Group will use the <a href="https://www.w3.org/Consortium/Legal/copyright-software">W3C Software and Document license</a> for all its deliverables.</p>
+      </section>
+
+
+
+      <section id="about">
+        <h2>
+          About this Charter
+        </h2>
+        <p>
+          This charter has been created according to <a href="https://www.w3.org/Consortium/Process/#GAGeneral">section 3.4</a> of the <a href="https://www.w3.org/Consortium/Process/">Process Document</a>. In the event of a conflict between this document or the provisions of any charter and the W3C Process, the W3C Process shall take precedence.
+        </p>
+
+        <section id="history">
+          <h3>
+            Charter History
+          </h3>
+
+          <p>The following table lists details of all changes from the initial charter, per the <a href="https://www.w3.org/Consortium/Process/#CharterReview">W3C Process Document (section 4.3, Advisory Committee Review of a Charter)</a>:</p>
+i          <table class="history">
+            <tbody>
+              <tr>
+                <th>
+                  Charter Period
+                </th>
+                <th>
+                  Start Date
+                </th>
+                <th>
+                  End Date
+                </th>
+                <th>
+                  Changes
+                </th>
+              </tr>
+              
+              <tr>
+                <th>
+                  <a href="https://www.w3.org/2014/12/wot-ig-charter.html">Initial Charter</a>
+                </th>
+                <td>
+                  21 January 2015
+                </td>
+                <td>
+                  31 March 2016
+                </td>
+                <td>
+                </td>
+              </tr>
+
+              <tr>
+                <th>
+                  <a href="https://lists.w3.org/Archives/Member/w3c-ac-members/2016AprJun/0038.html">Charter Extension</a>
+                </th>
+                <td>
+                  1 April 2016
+                </td>
+                <td>
+                  31 July 2016
+                </td>
+                <td>
+                  <ul>
+		    <li>Extended for rechartering process to complete</li>
+		  </ul>
+                </td>
+              </tr>
+
+              <tr>
+                <th>
+                  <a href="https://www.w3.org/2016/07/wot-ig-charter.html">Rechartered</a>
+                </th>
+                <td>
+                  1 August 2016
+                </td>
+                <td>
+                  31 December 2018
+                </td>
+                <td>
+                  <ul>
+                    <li>Clarified relation to chartered WoT Working Group</li>
+                    <li>Changed scope to explore role of semantic technologies</li>
+                  </ul>
+                </td>
+              </tr>
+
+              <tr>
+                <th>
+                  <a href="https://lists.w3.org/Archives/Member/w3c-ac-members/2019JanMar/0018.html">Charter Extension</a>
+                </th>
+                <td>
+                  1 January 2019
+                </td>
+                <td>
+                  30 June 2019
+                </td>
+                <td>
+                  <ul>
+                    <li>Matthias Kovatsch changed his affiliation and re-appointed as co-Chair.</li>
+                    <li>Yongjing Zhang stepped down as co-Chair.</li>
+                  </ul>
+                </td>
+              </tr>
+
+              <tr>
+                <th>
+                  <!--a href="https://lists.w3.org/Archives/Member/w3c-ac-members/2016AprJun/0038.html"-->Charter Extension<!--/a-->
+                </th>
+                <td>
+                  1 July 2019
+                </td>
+                <td>
+                  31 December 2019
+                </td>
+                <td>
+                  <ul>
+		    <li>Extended for rechartering process to complete</li>
+		  </ul>
+                </td>
+              </tr>
+
+              <tr>
+                <th>
+                  <a href="https://www.w3.org/2019/07/wot-ig-2019.html">Rechartered</a>
+                </th>
+                <td>
+                  22 October 2019
+                </td>
+                <td>
+                  30 June 2021
+                </td>
+                <td>
+                  <ul>
+                    <li>Simplified scope and deliverables to enable a broader set of Participants</li>
+                    <li>Updated coordination groups</li>
+                  </ul>
+                </td>
+              </tr>
+		    
+	      <tr>
+                <th>
+                  <!--a href="https://lists.w3.org/Archives/Member/w3c-ac-members/2016AprJun/0038.html"-->Charter Extension<!--/a-->
+                </th>
+                <td>
+                  1 July 2021
+                </td>
+                <td>
+                  31 December 2021
+                </td>
+                <td>
+                  <ul>
+		    <li>Extended for rechartering process to complete</li>
+		  </ul>
+                </td>
+              </tr>
+
+              <tr>
+                  <th>
+                      Charter Extension
+                  </th>
+                  <td>
+                      1 January 2022
+                  </td>
+                  <td>
+                      31 March 2022
+                  </td>
+                  <td>
+                      <ul>
+		                      <li>Extended for rechartering process to complete</li>
+		                  </ul>
+                  </td>
+              </tr>
+
+              <tr>
+                <th>
+                  <a href="https://www.w3.org/2021/12/wot-ig-2021.html">Rechartered</a>
+                </th>
+                <td>
+                  10 February 2022
+                </td>
+                <td>
+                  31 December 2023
+                </td>
+                <td>
+                  <ul>
+                    <li>Updated to new charter templates</li>
+                    <li>Updated coordination groups, including external liaisons</li>
+                  </ul>
+                </td>
+              </tr>
+            </tbody>
+          </table>
+        </section>
+
+        <section id="changelog">
+          <h3>Change log</h3>
+
+          <!-- Use this section for changes _after_ the charter was approved by the Director. -->
+          <p>Changes to this document are documented in this section.</p>
+          <!--
+          <dl id='changes'>
+            <dt>YYYY-MM-DD</dt>
+            <dd>[changes]]</dd>
+          </dl>
+          -->
+        </section>
+      </section>
+    </main>
+
+    <hr>
+
+    <footer>
+      <address>
+        <a href="mailto:ashimura@w3.org">Kazuyuki Ashimura</a>
+      </address>
+
+<p class="copyright">Copyright © 2023 <a href="https://www.w3.org/">World Wide Web Consortium</a>.<br>
+  <abbr title="World Wide Web Consortium">W3C</abbr><sup>®</sup>
+  <a href="https://www.w3.org/Consortium/Legal/ipr-notice#Legal_Disclaimer">liability</a>,
+  <a href="https://www.w3.org/Consortium/Legal/ipr-notice#W3C_Trademarks">trademark</a> and
+      <a rel="license" href="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document" title="W3C Software and Document Notice and License">permissive document license</a> rules apply.</p>
+      <hr>
+      <p><span class='todo'><a href="https://github.com/w3c/charter-drafts">Yes, it's on GitHub!</a>.</span></p>
+    </footer>
+
+  </body>
+</html>


### PR DESCRIPTION
Initial draft of renewed WoT IG charter, just copying over old charter into new template.   There are a set of outstanding issues to improve this charter.  This PR replaces PR https://github.com/w3c/wot/pull/1149