### PR TITLE
IG Charter 2023: Update Deliverables

### DIFF
--- a/wot-ig-2023-draft.html
+++ b/wot-ig-2023-draft.html
@@ -406,7 +406,7 @@
 		to support WoT developers when designing applications and/or Things.
 	    </li>
 	    Note however that some of the above documents, such as experience reports or tutorials,
-	    may also be created by associated Web of Things Community Groups.
+	    may also be created by Community Groups related to the Web of Things.
           </ul>
 
         </section>

--- a/wot-ig-2023-draft.html
+++ b/wot-ig-2023-draft.html
@@ -381,10 +381,10 @@
           Deliverables
         </h2>
         <p>
-          The primary deliverables of the WoT Interest Group are IG Notes that identify use cases and requirements 
-		for existing and/or new WoT building blocks (i.e., technical specifications by the WoT Working Group).
-          The IG Notes may contain the consensus of first implementation experiences gained by the group (e.g., during PlugFests).
-          The group will also maintain a public list of identified WoT building blocks that it is tracking and investigating.
+          The primary deliverable of the WoT Interest Group is an informative IG Note that identifies 
+	  <a href="https://www.w3.org/TR/wot-usecases/">WoT Use Cases and Requirements</a>.
+          This Note collects use cases from various stakeholders, analyzes them for
+	  requirements, and relates those requirements to specific WoT building blocks.
         </p>
 
         <section id="normative">
@@ -400,10 +400,13 @@
             Other non-normative documents may be created such as:
           </p>
           <ul>
-            <li>use case and requirement documents;</li>
-            <li>experience and/or implementation reports for identified building blocks;</li>
-            <li>primers/tutorials, best practice, implementation guidelines, or test case documents (including security) 
-		    to support WoT developers when designing applications and/or Things.</li>
+            <li>experience reports for identified building blocks;</li>
+	    <li>proposals for new building blocks, or approaches to satisfy identified requirements;</li>
+            <li>primers/tutorials, best practices, implementation guidelines, or test case documents (including security) 
+		to support WoT developers when designing applications and/or Things.
+	    </li>
+	    Note however that some of the above documents, such as experience reports or tutorials,
+	    may also be created by associated Web of Things Community Groups.
           </ul>
 
         </section>


### PR DESCRIPTION
Resolves #126 

- Focus on (and link to) Use Cases and Requirements Note as primary deliverable
- Leave others, including tutorials, but mention "associated Web of Things Community Groups" (since there are multiple of them now... should link to a section that lists them all)