### PR TITLE
IG charter decision policy

### DIFF
--- a/wot-ig-2023-draft.html
+++ b/wot-ig-2023-draft.html
@@ -662,6 +662,36 @@ on the public mailing list <a class="todo" id="public-name" href="mailto:public-
         <h2>
           Decision Policy
         </h2>
+      <p>To afford asynchronous decisions and organizational
+      deliberation, resolutions both proposed and taken in a
+      face-to-face meeting or teleconference will be considered
+      provisional. A call for consensus (CfC) will be issued for
+      all such resolutions (via email) with a response period from
+      5 to 10 working days, depending on the Chairs' evaluation of
+      the group consensus on the issue. If no objections are raised
+      by the end of the response period, the resolution will be
+      considered to have consensus as a resolution of the Working
+      Group.</p>
+      <p>In some cases, resolutions can be announced and proposed
+      in advance, by circulating an email to the group with
+      concrete proposed text for the resolution. In these cases,
+      the announcement can be considered the call for consensus
+      (CfC) and when the resolution is made by the group, it can be
+      considered final, at the discretion of the Chairs, if
+      sufficient time (5 to 10 working days, at the discretion of
+      the Chairs, as above) has been allowed for asynchronous
+      input. This process will be followed especially for
+      publication decisions which are then effective
+      immediately.</p>
+      <p>All decisions made by the group should be considered
+      resolved unless and until new information becomes available
+      or unless reopened at the discretion of the Chairs or the
+      Director.</p>
+      <p>This charter is written in accordance with the <a href=
+      "https://www.w3.org/Consortium/Process/#Votes">W3C Process
+      Document (Section 5.2.3, Deciding by Vote)</a> and includes
+      no voting procedures beyond what the Process Document
+      requires.</p>
         <p>
           This group will seek to make decisions through consensus and due process, 
           per the <a href="https://www.w3.org/Consortium/Process/#Consensus">W3C Process Document (section 5.2.1, Consensus)</a>. 
@@ -676,9 +706,21 @@ on the public mailing list <a class="todo" id="public-name" href="mailto:public-
         </p>
         <p>
           To afford asynchronous decisions and organizational deliberation, 
-		any resolution (including publication decisions) taken in a face-to-face meeting or teleconference will be considered provisional.
-          A call for consensus (CfC) will be issued for all resolutions (for example, via email and/or web-based survey), with a response period from one week to 10 working days, depending on the chair's evaluation of the group consensus on the issue.
-          If no objections are raised on the mailing list by the end of the response period, the resolution will be considered to have consensus as a resolution of the Interest Group.
+		      any resolution (including publication decisions) taken in a face-to-face meeting or teleconference will be considered provisional.
+          A call for consensus (CfC) will be issued for all resolutions (for example, via email and/or web-based survey), 
+          with a response period from one week to 10 working days, depending on the chair's evaluation of the group consensus on the issue.
+          If no objections are raised on the mailing list by the end of the response period, 
+          the resolution will be considered to have consensus as a resolution of the Interest Group.
+        </p>
+        <p>
+          In some cases, resolutions can be announced and proposed in advance, 
+          by circulating an email to the group with concrete proposed text for the resolution. 
+          In these cases, the announcement can be considered the call for consensus
+          (CfC) and when the resolution is made by the group, it can be considered final, 
+          at the discretion of the Chairs, if sufficient time (5 to 10 working days, at the discretion of
+          the Chairs, as above) has been allowed for asynchronous input. 
+          This process will be followed especially for publication decisions which are then effective
+          immediately.
         </p>
         <p>
           All decisions made by the group should be considered resolved unless and until new information becomes available or unless reopened at the discretion of the Chairs or the Director.

--- a/wot-ig-2023-draft.html
+++ b/wot-ig-2023-draft.html
@@ -662,36 +662,6 @@ on the public mailing list <a class="todo" id="public-name" href="mailto:public-
         <h2>
           Decision Policy
         </h2>
-      <p>To afford asynchronous decisions and organizational
-      deliberation, resolutions both proposed and taken in a
-      face-to-face meeting or teleconference will be considered
-      provisional. A call for consensus (CfC) will be issued for
-      all such resolutions (via email) with a response period from
-      5 to 10 working days, depending on the Chairs' evaluation of
-      the group consensus on the issue. If no objections are raised
-      by the end of the response period, the resolution will be
-      considered to have consensus as a resolution of the Working
-      Group.</p>
-      <p>In some cases, resolutions can be announced and proposed
-      in advance, by circulating an email to the group with
-      concrete proposed text for the resolution. In these cases,
-      the announcement can be considered the call for consensus
-      (CfC) and when the resolution is made by the group, it can be
-      considered final, at the discretion of the Chairs, if
-      sufficient time (5 to 10 working days, at the discretion of
-      the Chairs, as above) has been allowed for asynchronous
-      input. This process will be followed especially for
-      publication decisions which are then effective
-      immediately.</p>
-      <p>All decisions made by the group should be considered
-      resolved unless and until new information becomes available
-      or unless reopened at the discretion of the Chairs or the
-      Director.</p>
-      <p>This charter is written in accordance with the <a href=
-      "https://www.w3.org/Consortium/Process/#Votes">W3C Process
-      Document (Section 5.2.3, Deciding by Vote)</a> and includes
-      no voting procedures beyond what the Process Document
-      requires.</p>
         <p>
           This group will seek to make decisions through consensus and due process, 
           per the <a href="https://www.w3.org/Consortium/Process/#Consensus">W3C Process Document (section 5.2.1, Consensus)</a>. 


### PR DESCRIPTION
- Copy policy from WG charter, except for necessary changes (Working -> Interest, etc).
- One extra line at the end due to new template