### PR TITLE
IG charter communication policy

### DIFF
--- a/wot-ig-2023-draft.html
+++ b/wot-ig-2023-draft.html
@@ -641,7 +641,7 @@ test suite of every feature defined in the specification.</p>
       deliverables, issues, actions, status, participants, and
       meetings) will be available from the 
       <a href="https://www.w3.org/groups/ig/wot">Web of Things Interest Group home page.</a>
-      and the more comprehensive
+      and the more general
       <a href= "https://www.w3.org/WoT/">Web of Things (WoT) home page.</a></p>
       <p>Most Web of Things (WoT) Interest Group teleconferences
       will focus on discussion of particular deliverables, and

--- a/wot-ig-2023-draft.html
+++ b/wot-ig-2023-draft.html
@@ -641,7 +641,6 @@ test suite of every feature defined in the specification.</p>
       deliverables, issues, actions, status, participants, and
       meetings) will be available from the 
       <a href="https://www.w3.org/groups/ig/wot">Web of Things Interest Group home page.</a>
-      and the more general
       <a href= "https://www.w3.org/WoT/">Web of Things (WoT) home page.</a></p>
       <p>Most Web of Things (WoT) Interest Group teleconferences
       will focus on discussion of particular deliverables, and

--- a/wot-ig-2023-draft.html
+++ b/wot-ig-2023-draft.html
@@ -626,36 +626,39 @@ test suite of every feature defined in the specification.</p>
         <h2>
           Communication
         </h2>
-        <p id="public">
-          Technical discussions for this Interest Group are conducted in 
-          <a href="https://www.w3.org/Consortium/Process/#confidentiality-levels">public</a>: 
-          the meeting minutes from teleconference and face-to-face meetings will be archived for public review,
-          and technical discussions and issue tracking will be conducted in a manner that
-          can be both read and written to by the general public.
-          Working Drafts and Editor's Drafts of specifications will be developed in public repositories 
-          and may permit direct public contribution requests.
-          The meetings themselves are not open to public participation, however.
-        </p>
-        <p>
-          Information about the group (including details about deliverables, issues, actions, status, participants, and meetings) 
-           will be available from the <a href="https://www.w3.org/groups/ig/wot">Web of Things Interest Group home page.</a>
-        </p>
-        <p>
-          Most Web of Things Interest Group teleconferences will focus on discussion of particular specifications, 
-          and will be conducted on an as-needed basis.
-        </p>
-        <p>
-          This group primarily conducts its technical work  
-<!--
-on the public mailing list <a class="todo" id="public-name" href="mailto:public-[email-list]@w3.org">public-<i class="todo">[email-list]</i>@w3.org</a> (<a class="todo" href="https://lists.w3.org/Archives/Public/public-[email-list]/">archive</a>)
-          <i class="todo">or</i> on <a class="todo" id="public-github" href="[link to Github repo]">GitHub issues</a>.
-          The public is invited to review, discuss and contribute to this work.
--->
-                on <a id="public-github" href="https://github.com/w3c/wot">GitHub issues</a>.
-                The public is invited to review, discuss and contribute to this work.</p> 
-        <p>
-          The group may use a Member-confidential mailing list for administrative purposes and, at the discretion of the Chairs and members of the group, for member-only discussions in special cases when a participant requests such a discussion.
-        </p>
+     <p id="public">Technical discussions for this Interest Group
+      are conducted in <a href=
+      "https://www.w3.org/Consortium/Process/#confidentiality-levels">
+      public</a>: the meeting minutes from teleconference and
+      face-to-face meetings will be archived for public review, and
+      technical discussions and issue tracking will be conducted in
+      a manner that can be both read and written to by the general
+      public. Working Drafts and Editor's Drafts of deliverables
+      will be developed in public repositories and may permit
+      direct public contribution requests. The meetings themselves
+      are not open to public participation, however.</p>
+      <p>Information about the group (including details about
+      deliverables, issues, actions, status, participants, and
+      meetings) will be available from the 
+      <a href="https://www.w3.org/groups/ig/wot">Web of Things Interest Group home page.</a>
+      and the more comprehensive
+      <a href= "https://www.w3.org/WoT/">Web of Things (WoT) home page.</a></p>
+      <p>Most Web of Things (WoT) Interest Group teleconferences
+      will focus on discussion of particular deliverables, and
+      will be conducted on an as-needed basis. However, one
+      teleconference will be held weekly to coordinate activities
+      among the task forces responsible for each deliverable.</p>
+      <p>This group primarily conducts its technical work on <a id=
+      "public-github" href="https://github.com/w3c/wot">GitHub
+      issues</a>, using a main repository for general topics and
+      more specific repositories for individual deliverables. The
+      public is invited to review, discuss and contribute to this
+      work.</p>
+      <p>The group may use a Member-confidential mailing list for
+      administrative purposes and, at the discretion of the Chairs
+      and members of the group, for member-only discussions in
+      special cases when a participant requests such a
+      discussion.</p>
       </section>
 
       <section id="decisions">

--- a/wot-ig-2023-draft.html
+++ b/wot-ig-2023-draft.html
@@ -641,7 +641,7 @@ test suite of every feature defined in the specification.</p>
       deliverables, issues, actions, status, participants, and
       meetings) will be available from the 
       <a href="https://www.w3.org/groups/ig/wot">Web of Things Interest Group home page.</a>
-      <a href= "https://www.w3.org/WoT/">Web of Things (WoT) home page.</a></p>
+</p>
       <p>Most Web of Things (WoT) Interest Group teleconferences
       will focus on discussion of particular deliverables, and
       will be conducted on an as-needed basis. However, one


### PR DESCRIPTION
- copy and edit comm policy from wg
- change "Working" to "Interest" and "specification" to "deliverable"
- Add links to both IG home page and more general WoT home page