### PR TITLE
Fixes to charter draft

### DIFF
--- a/wot-ig-2023-draft.html
+++ b/wot-ig-2023-draft.html
@@ -263,7 +263,7 @@
                     the current working assumptions in regard to the Web of Things</li>
                 <li>Develop use cases and functional requirements for the WoT Working Group to refine into 
                     technical requirements and specifications</li>
-                <li>Manage the Public Appearance of the Web of Things through the Marketing Task Force</li>
+                <li>Manage the Public Appearance of the Web of Things</li>
             </ul>
         </div>
 

--- a/wot-ig-2023-draft.html
+++ b/wot-ig-2023-draft.html
@@ -263,14 +263,15 @@
                     the current working assumptions in regard to the Web of Things</li>
                 <li>Develop use cases and functional requirements for the WoT Working Group to refine into 
                     technical requirements and specifications</li>
-                <li>Oversee the Marketing Taks Force</li>
+                <li>Manage the Public Appearance of the Web of Things through the Marketing Task Force</li>
             </ul>
         </div>
 
         <p>
           <a href="./wot-ig-2023_files/wot-ig-2019-relationship.png"><img id="relationships" src="./wot-ig-2023_files/wot-ig-relationship.png" alt="relationship between WoT IG and WG"></a>
           The Web of Things Interest Group (WoT IG) is a forum for discussion of ideas relating to the Web of Things
-          and is intended to complement the role of the Web of Things Working Group (WoT WG). The WoT IG will submit new use cases and functional requirements to the WoT Working Group, and organize interoperability test events for hands-on evaluation of WoT standards and work in progress.
+          and is intended to complement the role of the Web of Things Working Group (WoT WG). The WoT IG will submit requirements originating from use cases to the WoT Working Group, and organize 
+	  interoperability test events for hands-on evaluation of WoT standards and work in progress.
           The WoT IG will work with the WoT Community Groups to capture new use case and requirements, and collaborate on Plugfests, testing, and outreach.
           
           Conversely, the WoT IG will consider new topics that are submitted to it by the WoT WG.
@@ -375,7 +376,7 @@
           test case documents.
         </p>
 	<p>Regarding accessibilty,
-	   Use cases will be analyzed to identify accessibility requirements
+	   use cases will be analyzed to identify accessibility requirements
 	   whenever possible, and use cases specifically supporting accessibility
 	   will be sought out.
 	</p>


### PR DESCRIPTION
Mostly small things, I think.

Also, I do not understand why https://github.com/w3c/wot-charter-drafts/blob/main/relationship.md is not considered at all in the charter and we worked writing the same thing twice, having redundant content. 